### PR TITLE
SPA auth failure should redirect to RefApp login

### DIFF
--- a/configuration/frontend/assets/config.json
+++ b/configuration/frontend/assets/config.json
@@ -1,4 +1,9 @@
 {
+  "@openmrs/esm-api": {
+    "redirectAuthFailure": {
+      "url": "/mirebalais/login.htm"
+    }
+  },
   "@openmrs/esm-login": {
     "logo": {
       "src": "/mirebalais/frontend/assets/pih-logo.png",


### PR DESCRIPTION
Fixing the configuration. The existing settings (including defaults) are shown here:

![Screenshot from 2020-05-11 20-33-56](https://user-images.githubusercontent.com/1031876/81635745-d683f000-93c6-11ea-9e5f-037d1f0cd248.png)
