### PR TITLE
simple utility script to pull in both PIH EMR repo and latest repo

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# if there's a "config-pihemr" or "openmrs-config-pihemr" directory at the same level as this project,
+# run a pull there as well
+
+if [[ -d '../config-pihemr' ]]; then
+    (cd ../config-pihemr && git pull)
+elif [[ -d '../openmrs-config-pihemr' ]]; then
+    (cd ../openmrs-config-pihemr && git pull)
+else
+  echo "Unable to find PIH-EMR config, skipping pulling it"
+fi
+
+git pull


### PR DESCRIPTION
Just a simple script that does a git pull on both the config-zl repo and the config-pihemr repo if it's in a directory relative to the ZL directory.

So the daily "update my environment" routine would be:

cd [config-zl directory]
mvn openmrs-sdk:pull
mvn openmrs-sdk:deploy
./pull.sh
./install.sh [serverId]
mvn openmrs-sdk:run

Would be great to get a another layer on top of this at some point, but this seemed like a quick-win... I can copy it to the other config directories as well.
