### PR TITLE
Add field for TB Other

### DIFF
--- a/configuration/pih/htmlforms/hiv/section-hiv-state.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-state.xml
@@ -10,10 +10,21 @@
                 vertical-align: top;
             }
 
-            .two-columns {
+            .two-columns-legacy {
                 column-count: 2;
                 -webkit-column-count: 2;
                 -moz-column-count: 2;
+            }
+
+            .two-columns {
+                display: table;
+                height: 100%;
+                width: 100%;
+            }
+
+            .two-columns > div {
+                display: table-cell;
+                width: 50%;
             }
 
             p.radio > * {
@@ -496,7 +507,7 @@
                 <p class="small">
                     <obs conceptId="CIEL:159599"/>
                 </p>
-                <div class="two-columns">
+                <div class="two-columns-legacy">
                     <p class="radio">
                         <!-- ARV medications  -->
                         <obsgroup groupingConceptId="PIH:13156">
@@ -603,31 +614,38 @@
                 <uimessage code="pihcore.antiTbTreatment"/>
             </h4>
 
-            <p class="small">
-                <obs id="takingAntiTB"
-                     conceptId="CIEL:159798" style="radio"
-                     answerConceptIds="CIEL:1065,CIEL:1066"
-                     answerCodes="emr.yes,pihcore.none.label" >
-                    <controls>
-                        <when value="CIEL:1065" thenDisplay="#current-tb-meds"/>
-                    </controls>
-                </obs>
-            </p>
+            <div  class="two-columns">
+                <div>
+                    <p class="small">
+                        <obs id="takingAntiTB"
+                            conceptId="CIEL:159798" style="radio"
+                            answerConceptIds="CIEL:1065,CIEL:1066"
+                            answerCodes="emr.yes,pihcore.none.label" >
+                            <controls>
+                                <when value="CIEL:1065" thenDisplay=".current-tb-meds"/>
+                            </controls>
+                        </obs>
+                    </p>
 
-            <div id="current-tb-meds" class="two-columns">
-                <label>
-                    <uimessage code="pihcore.startDate" />
-                </label>
-                <obs conceptId="CIEL:1113" />
-                <br/>
-
-                <p class="radio">
-                    <obs conceptId="CIEL:1111" style="radio"
-                         answerConceptIds="PIH:2406,PIH:2408,CIEL:159909"
-                         answerCodes="pihcore.tb.initialTreatment,pihcore.tb.retreatment,pihcore.tb.mdrtbTreatment"
-                         answerSeparator="&lt;br /&gt;" />
-                    <obs conceptId="CIEL:160136" />
-                </p>
+                    <div class="current-tb-meds">
+                        <label>
+                            <uimessage code="pihcore.startDate" />
+                        </label>
+                        <obs conceptId="CIEL:1113" />
+                    </div>
+                </div>
+                <div class="current-tb-meds">
+                    <p class="radio">
+                        <obs conceptId="CIEL:1111" style="radio"
+                            answerConceptIds="PIH:2406,PIH:2408,CIEL:159909"
+                            answerCodes="pihcore.tb.initialTreatment,pihcore.tb.retreatment,pihcore.tb.mdrtbTreatment"
+                            answerSeparator="&lt;br /&gt;"/>
+                        <obs conceptId="CIEL:160136" />
+                    </p>
+                    <p>
+                        <obs conceptId="PIH:Anti TB free text" labelCode="zl.ifOtherSpecify" />
+                    </p>
+                </div>
             </div>
 
             <h4>
@@ -778,7 +796,7 @@
     <section id="tb-screen" sectionTag="fieldset" headerTag="legend" headerStyle="title"
              headerCode="pihcore.tbscreen.title">
         <div class="section-container">
-            <div class="two-columns">
+            <div class="two-columns-legacy">
                 <repeat with="['feverSweats','11565'],['wtLoss3kg','11566'],['cough','11567'],['tbContact','11568'],['painfulNodes','11569'],['bloodyCough','970'],['dyspnea','5960'],['chestPain','136']">
                     <div class="radio tb-screening-question">
                         <obs conceptIds="PIH:11563,PIH:11564"
@@ -803,7 +821,7 @@
     <section id="sexual-activity" sectionTag="fieldset" headerTag="legend" headerStyle="title"
              headerCode="zl.consultNote.sexualActivities.label">
         <div class="section-container">
-            <div class="two-columns">
+            <div class="two-columns-legacy">
                 <p class="radio">
                     <label>
                         <uimessage code="zl.sexuallyActive"/>?
@@ -897,7 +915,7 @@
                          style="checkbox"/>
 
                     <div id="pregnant">
-                        <div class="two-columns">
+                        <div class="two-columns-legacy">
                             <!-- Last menstrual period (LMP or DDR) -->
                             <p>
                                 <label>
@@ -919,7 +937,7 @@
                             </p>
                         </div>
 
-                        <div id="calculated-edd-and-gestational" class="two-columns hidden">
+                        <div id="calculated-edd-and-gestational" class="two-columns-legacy hidden">
                             <p>
                                 <span id="calculated-gestational-age-wrapper">
                                     <span id="calculated-gestational-age-label">
@@ -1144,7 +1162,7 @@
             </label>
             <br/>
 
-            <div class="two-columns">
+            <div class="two-columns-legacy">
                 <repeat with="['One'],
                               ['Two'],
                               ['Three'],

--- a/configuration/pih/htmlforms/hiv/section-hiv-state.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-state.xml
@@ -640,7 +640,7 @@
                             answerConceptIds="PIH:2406,PIH:2408,CIEL:159909"
                             answerCodes="pihcore.tb.initialTreatment,pihcore.tb.retreatment,pihcore.tb.mdrtbTreatment"
                             answerSeparator="&lt;br /&gt;"/>
-                        <obs conceptId="CIEL:160136" />
+                        <obs conceptId="CIEL:160136" size="14" />
                     </p>
                     <p>
                         <obs conceptId="PIH:Anti TB free text" labelCode="zl.ifOtherSpecify" />


### PR DESCRIPTION
This also introduces a better way of doing a two-column layout. Unfortunately it requires a little bit of adaptation—it requires that each column be wrapped in its own div. But the result is columns that are 100% reliable, i.e. they won't shift around based on screen size, zoom, browser version, or any of that.

I just want to run this by you, @lnball , before I go ahead and change them all, at least for this form section.

The new concept is [Anti-TB (free text)](https://concepts.pih-emr.org/openmrs/dictionary/concept.htm?conceptId=13328) and was added to Haiti_HIV-161 in https://github.com/PIH/openmrs-config-pihemr/commit/57221a563db2f924f08c4952d78ca787e22b8122 (which has a completely erroneous comment, my bad).

![Screenshot from 2021-02-24 13-05-16](https://user-images.githubusercontent.com/1031876/109066418-e6dd3100-76a1-11eb-9661-78b4189f4979.png)

![Screenshot from 2021-02-24 13-25-17](https://user-images.githubusercontent.com/1031876/109067772-d037d980-76a3-11eb-8095-5934ae0a2634.png)
