### PR TITLE
change plan clinicial impressions and action plan to textareas

### DIFF
--- a/configuration/pih/htmlforms/hiv/section-hiv-plan.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-plan.xml
@@ -1391,12 +1391,12 @@
             <label>
                 <uimessage code="pihcore.consult.clinicalImpressions"/>
             </label>
-            <obs conceptId="CIEL:162749" style="text"/>
+            <obs conceptId="CIEL:162749" style="textarea" rows="8"/>
 
             <label>
                 <uimessage code="pihcore.actionPlan"/>
             </label>
-            <obs conceptId="PIH:1620" style="text"/>
+            <obs conceptId="PIH:1620" style="textarea" rows="8"/>
 
             <p class="narrow">
                 <label>

--- a/configuration/pih/htmlforms/hiv/section-hiv-plan_v3.0.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-plan_v3.0.xml
@@ -1170,12 +1170,12 @@
             <label>
                 <uimessage code="pihcore.consult.clinicalImpressions"/>
             </label>
-            <obs conceptId="CIEL:162749" style="text"/>
+            <obs conceptId="CIEL:162749" style="textarea" rows="8"/>
 
             <label>
                 <uimessage code="pihcore.actionPlan"/>
             </label>
-            <obs conceptId="PIH:1620" style="text"/>
+            <obs conceptId="PIH:1620" style="textarea" rows="8"/>
 
             <p class="narrow">
                 <label>


### PR DESCRIPTION
@lnball I figure these should be textareas?  (It became relevant recently because we are migrating in the "action plan" and the incoming data has carriage returns which aren't displayed in the plain "text" widget)