### PR TITLE
UHM-5110: Make intake plan prophylaxis form look like what's in the HIV EMR

### DIFF
--- a/configuration/pih/htmlforms/hiv/section-hiv-plan_v3.0.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-plan_v3.0.xml
@@ -483,7 +483,7 @@
                             </td>
                             <td>
                                 <label>
-                                    <uimessage code="pihcore.statusAndOrder" />
+                                    <uimessage code="pihcore.status" />
                                 </label>
                             </td>
                             <td>
@@ -492,9 +492,11 @@
                                 </label>
                             </td>
                             <td>
+                                <label>
+                                    <uimessage code="pihcore.numberPerDay" />
+                                </label>
                             </td>
                         </tr>
-
                         <repeat>
                             <template>
                                 <obsgroup groupingConceptId="PIH:Prescription construct">
@@ -508,160 +510,53 @@
                                         <td class="{drugname}-treat">
                                             <obs conceptId="PIH:PROPHYLAXIS STARTED"
                                                  answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.initiated" answerLabel=""
-                                                 toggle="{drugname}-start-date"/>
+                                                 labelCode="pihcore.initiated" answerLabel=""/>
                                             <obs conceptId="PIH:Prophylaxis should continue"
                                                  answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.continued" answerLabel="" />
+                                                 labelCode="pihcore.continued" answerLabel=""/>
                                             <obs conceptId="PIH:Stop Rx" style="checkbox"
                                                  answerConceptId="CIEL:1065"
-                                                 labelCode="pihcore.stopped" answerLabel=""
-                                                 toggle="{drugname}-reason-stopped"/>
+                                                 labelCode="pihcore.stopped" answerLabel=""/>
                                         </td>
                                         <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded" />
+                                            <obs conceptId="PIH:Prescription instructions non-coded"/>
                                         </td>
                                         <td class="{drugname}-treat">
-                                            <p class="{drugname}-start-date">
-                                                <!-- Treatment start date -->
-                                                <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                     labelCode="pihcore.startDate" />
-                                            </p>
-                                            <p class="{drugname}-reason-stopped small-input">
-                                                <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                     labelCode="pihcore.stopReason" />
-                                            </p>
+                                            <obs conceptId="PIH:Number per day non coded"/>
                                         </td>
                                     </tr>
                                 </obsgroup>
                             </template>
                             <render conceptMap="CIEL:105281" drugname="Cotrimoxazole" />
-                        </repeat>
-
-                        <repeat>
-                            <template>
-                                <obsgroup groupingConceptId="PIH:10742">
-                                    <tr>
-                                        <td>
-                                            <obs conceptId="CIEL:1282" answerConceptId="{conceptMap}"
-                                                answerLabel="{drugname}"
-                                                toggle="{id: '{drugname}-treat', style: 'dim'}"/>
-                                            <p class="radio {drugname}-treat">
-                                                <obs conceptId="PIH:13154" style="radio"
-                                                    answerConceptIds="CIEL:159943, CIEL:159944"
-                                                    answerSeparator="&lt;br /&gt;"/>
-                                            </p>
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <obs conceptId="PIH:PROPHYLAXIS STARTED"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.initiated" answerLabel=""
-                                                 toggle="{drugname}-start-date"/>
-                                            <obs conceptId="PIH:Prophylaxis should continue"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.continued" answerLabel="" />
-                                            <obs conceptId="PIH:Stop Rx" style="checkbox"
-                                                 answerConceptId="CIEL:1065"
-                                                 labelCode="pihcore.stopped" answerLabel=""
-                                                 toggle="{drugname}-reason-stopped"/>
-                                        </td>
-                                        <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded" />
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <p class="{drugname}-start-date">
-                                                <!-- Treatment start date -->
-                                                <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                     labelCode="pihcore.startDate" />
-                                            </p>
-                                            <p class="{drugname}-reason-stopped small-input">
-                                                <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                     labelCode="pihcore.stopReason" />
-                                            </p>
-                                        </td>
-                                    </tr>
-                                </obsgroup>
-                            </template>
                             <render conceptMap="CIEL:78280"  drugname="Isoniazide" />
-                        </repeat>
-
-                        <repeat>
-                            <template>
-                                <obsgroup groupingConceptId="PIH:10742">
-                                    <tr>
-                                        <td>
-                                            <obs conceptId="CIEL:1282" answerConceptId="{conceptMap}"
-                                                answerLabel="{drugname}"
-                                                toggle="{id: '{drugname}-treat', style: 'dim'}"/>
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <obs conceptId="PIH:PROPHYLAXIS STARTED"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.initiated" answerLabel=""
-                                                 toggle="{drugname}-start-date"/>
-                                            <obs conceptId="PIH:Prophylaxis should continue"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.continued" answerLabel="" />
-                                            <obs conceptId="PIH:Stop Rx" style="checkbox"
-                                                 answerConceptId="CIEL:1065"
-                                                 labelCode="pihcore.stopped" answerLabel=""
-                                                 toggle="{drugname}-reason-stopped"/>
-                                        </td>
-                                        <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded" />
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <p class="{drugname}-start-date">
-                                                <!-- Treatment start date -->
-                                                <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                     labelCode="pihcore.startDate" />
-                                            </p>
-                                            <p class="{drugname}-reason-stopped small-input">
-                                                <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                     labelCode="pihcore.stopReason" />
-                                            </p>
-                                        </td>
-                                    </tr>
-                                </obsgroup>
-                            </template>
                             <render conceptMap="CIEL:76488"  drugname="Fluconazole" />
-                            <render conceptMap="CIEL:74250"  drugname="Dapsone" />
                         </repeat>
 
-                        <obsgroup groupingConceptId="PIH:10742">
+                        <obsgroup groupingConceptId="PIH:Prescription construct">
                             <tr>
-                                <td class="small-input">
-                                    <obs conceptId="CIEL:1282"
-                                        answerConceptId="PIH:3120" answerCode="pihcore.other"
-                                        toggle="{id: '{other-pro-treat}', style: 'dim'}"
+                                <td>
+                                    <!-- Medication orders -->
+                                    <obs conceptId="CIEL:1282" answerConceptId="PIH:3120"
+                                        answerLabel="other-pro"
+                                        toggle="{id: 'other-pro-treat', style: 'dim'}"
                                         commentFieldLabel="specify:" />
                                 </td>
                                 <td class="other-pro-treat">
                                     <obs conceptId="PIH:PROPHYLAXIS STARTED"
                                             answerConceptId="CIEL:1065" style="checkbox"
-                                            labelCode="pihcore.initiated" answerLabel=""
-                                            toggle="other-pro-start-date"/>
+                                            labelCode="pihcore.initiated" answerLabel=""/>
                                     <obs conceptId="PIH:Prophylaxis should continue"
                                             answerConceptId="CIEL:1065" style="checkbox"
-                                            labelCode="pihcore.continued" answerLabel="" />
+                                            labelCode="pihcore.continued" answerLabel=""/>
                                     <obs conceptId="PIH:Stop Rx" style="checkbox"
                                             answerConceptId="CIEL:1065"
-                                            labelCode="pihcore.stopped" answerLabel=""
-                                            toggle="other-pro-reason-stopped"/>
+                                            labelCode="pihcore.stopped" answerLabel=""/>
                                 </td>
                                 <td class="other-pro-treat small-input">
-                                    <obs conceptId="PIH:Prescription instructions non-coded" />
+                                    <obs conceptId="PIH:Prescription instructions non-coded"/>
                                 </td>
                                 <td class="other-pro-treat">
-                                    <p class="other-pro-start-date">
-                                        <!-- Treatment start date -->
-                                        <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                labelCode="pihcore.startDate" />
-                                    </p>
-                                    <p class="other-pro-reason-stopped small-input">
-                                        <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                labelCode="pihcore.stopReason" />
-                                    </p>
+                                    <obs conceptId="PIH:Number per day non coded"/>
                                 </td>
                             </tr>
                         </obsgroup>

--- a/configuration/pih/htmlforms/hiv/section-hiv-plan_v3.0.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-plan_v3.0.xml
@@ -487,13 +487,11 @@
                                 </label>
                             </td>
                             <td>
-                                <label>
-                                    <uimessage code="pihcore.dosage" />
-                                </label>
+                                <!-- Labels are on the input elements -->
                             </td>
                             <td>
                                 <label>
-                                    <uimessage code="pihcore.numberPerDay" />
+                                    <uimessage code="pihcore.stopReason" />
                                 </label>
                             </td>
                         </tr>
@@ -519,10 +517,15 @@
                                                  labelCode="pihcore.stopped" answerLabel=""/>
                                         </td>
                                         <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded"/>
+                                            <p>
+                                                <obs conceptId="PIH:Prescription instructions non-coded" labelCode="pihcore.dosage"/>
+                                            </p>
+                                            <p>
+                                                <obs conceptId="PIH:Number per day non coded" labelCode="pihcore.numberPerDay"/>
+                                            </p>
                                         </td>
                                         <td class="{drugname}-treat">
-                                            <obs conceptId="PIH:Number per day non coded"/>
+                                            <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT" />
                                         </td>
                                     </tr>
                                 </obsgroup>
@@ -531,6 +534,23 @@
                             <render conceptMap="CIEL:78280"  drugname="Isoniazide" />
                             <render conceptMap="CIEL:76488"  drugname="Fluconazole" />
                         </repeat>
+
+                        <obsgroup groupingConceptId="PIH:Prescription construct">
+                            <tr>
+                                <td>
+                                    <!-- Medication orders -->
+                                    <obs conceptId="CIEL:1282" answerConceptId="PIH:MOSQUITO NET"
+                                        answerLabel="Moustiquaire"
+                                        toggle="{id: 'mosquito-net-treat', style: 'dim'}"/>
+
+                                </td>
+                                <td class="mosquito-net-treat">
+                                    <obs conceptId="PIH:PROPHYLAXIS STARTED"
+                                            answerConceptId="CIEL:1065" style="checkbox"
+                                            labelCode="pihcore.initiated" answerLabel=""/>
+                                </td>
+                            </tr>
+                        </obsgroup>
 
                         <obsgroup groupingConceptId="PIH:Prescription construct">
                             <tr>
@@ -553,10 +573,15 @@
                                             labelCode="pihcore.stopped" answerLabel=""/>
                                 </td>
                                 <td class="other-pro-treat small-input">
-                                    <obs conceptId="PIH:Prescription instructions non-coded"/>
+                                    <p>
+                                        <obs conceptId="PIH:Prescription instructions non-coded" labelCode="pihcore.dosage"/>
+                                    </p>
+                                    <p>
+                                        <obs conceptId="PIH:Number per day non coded" labelCode="pihcore.numberPerDay"/>
+                                    </p>
                                 </td>
                                 <td class="other-pro-treat">
-                                    <obs conceptId="PIH:Number per day non coded"/>
+                                    <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT" />
                                 </td>
                             </tr>
                         </obsgroup>


### PR DESCRIPTION
For https://pihemr.atlassian.net/browse/UHM-5110
A follow-up to https://pihemr.atlassian.net/browse/UHM-5284

![hiv emr prophylaxes](https://user-images.githubusercontent.com/1031876/112065827-97641680-8b22-11eb-9962-a35f03053d1b.png)

![Screenshot from 2021-03-22 16-53-57](https://user-images.githubusercontent.com/1031876/112072519-3a229200-8b2f-11eb-8efb-63daa7df9a11.png)


