### PR TITLE
UHM-5328 - Switch Prophylaxis section on v4 "Plan" to use drug orders

### DIFF
--- a/configuration/pih/htmlforms/hiv/section-hiv-plan.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-plan.xml
@@ -127,42 +127,6 @@
         </div>
     </section>
 
-    <style>
-        #test-orders-new .orderwidget-history-section {
-            display:inline-block;
-        }
-        #test-orders-new .order-action-section {
-            display:inline-block;
-        }
-        #test-orders-new .order-cancel-action-section {
-            display: inline-block;
-            padding-left: 10px;
-            vertical-align: middle;
-        }
-    </style>
-
-    <section id="test-orders-new" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="Lab Ordering Test Example">
-        <order orderType="52a447d3-a64a-11e3-9aeb-50e549534c5e">
-            <orderTemplate>
-                <orderProperty name="action">
-                    <option value="NEW" label=" "/>
-                    <option value="DISCONTINUE"/>
-                </orderProperty>
-                <orderProperty name="concept" label=" ">
-                    <optionGroup concept="PIH:11683" groupLabel="pihcore.lab.hematology.title"/>
-                    <optionGroup concept="PIH:12260" groupLabel="pihcore.lab.parasitology.title"/>
-                    <optionGroup concept="PIH:3642" groupLabel="pihcore.lab.biochemistry.title"/>
-                    <optionGroup concept="PIH:12324" groupLabel="pihcore.lab.serology.title"/>
-                    <optionGroup concept="PIH:10582" groupLabel="pihcore.lab.tb.title"/>
-                    <optionGroup concept="PIH:10561" groupLabel="pihcore.lab.hiv.title"/>
-                </orderProperty>
-                <div style="display:none;">
-                    <orderProperty name="careSetting" value="OUTPATIENT"/>
-                </div>
-            </orderTemplate>
-        </order>
-    </section>
-
     <!-- ToDo: This section is duplicated by the section-lab-order.xml and should be replace
          with including forms within htmlforms.  Formlets? -->
     <section id="test-orders" sectionTag="fieldset" headerTag="legend" headerStyle="title"
@@ -489,224 +453,104 @@
         </div>
     </section>
 
-    <!-- Stolen from the dispensing module, but using prescription construct instead of dispensing -->
-    <section id="id-treatment" sectionTag="fieldset" headerTag="legend" headerStyle="title"
-             headerCode="pihcore.treatment">
+    <style type="text/css">
+        .orderwidget-section-header {
+            font-size: 16px;
+        }
+        .order-field {
+            display: inline-block;
+            padding: 0px;
+        }
+        .order-field.action {
+            display: block;
+        }
+        .order-field.dateActivated {
+            padding-right: 20px;
+        }
+        .order-field-label {
+            display: inline-block;
+            padding-right: 5px;
+            vertical-align: middle;
+        }
+        .order-field-label:after {
+            content: "";
+            white-space: pre;
+        }
+        .order-field-widget {
+            display: inline-block;
+        }
+    </style>
 
+    <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d306a-40c4-11e7-a919-92ebcb67fe33'">
+        <section id="id-treatment-prophylaxis" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.prophylaxis">
+            <div class="section-container-color">
+
+                <drugOrder>
+                    <orderTemplate>
+                        <orderProperty name="action"/>
+                        <div style="padding:0px;">
+                            <orderProperty name="concept" label="Drug">
+                                <option value="CIEL:105281" label="Cotrimoxazole" />
+                                <option value="CIEL:78280"  label="Isoniazide" />
+                                <option value="CIEL:76488"  label="Fluconazole" />
+                                <option value="CIEL:74250"  label="Dapsone" />
+                            </orderProperty>
+                        </div>
+                        <div style="padding:0px;">
+                            <orderProperty name="drug" label="Formulation"/>
+                        </div>
+                        <div style="padding:0px;">
+                            <orderProperty name="drugNonCoded" label="Non-coded Formulation"/>
+                        </div>
+                        <div style="padding:0x;">
+                            <orderProperty name="dosingType"/>
+                        </div>
+                        <div style="padding:0px;">
+                            <orderProperty name="dose" label="pihcore.visitNote.plan.dose"/>
+                            <orderProperty name="doseUnits" label=" "/>
+                            <orderProperty name="frequency" label=" x "/>
+                            <orderProperty name="route" label=" "/>
+                            <orderProperty name="dosingInstructions" textArea="true" textAreaRows="3" textAreaColumns="50" label=" "/>
+                        </div>
+                        <div style="padding:0px;">
+                            <orderProperty name="dateActivated" label="pihcore.starting"/>
+                            <orderProperty name="duration" label="pihcore.visitNote.for"/>
+                            <orderProperty name="durationUnits" label=" "/>
+                        </div>
+                        <div style="padding:0px;">
+                            <orderProperty name="quantity" label="pihcore.quantity"/>
+                            <orderProperty name="quantityUnits" label=" "/>
+                            <orderProperty name="numRefills" label="pihcore.refills"/>
+                        </div>
+                        <div style="display:none;">
+                            <orderProperty name="urgency" value="ROUTINE"/>
+                            <orderProperty name="previousOrder"/>
+                            <orderProperty name="careSetting" value="OUTPATIENT"/>
+                            <orderProperty name="orderReason" value="1691AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+                        </div>
+                        <div style="display:none;" class="order-discontinueReason">
+                            <orderProperty name="discontinueReason">
+                                <option value="CIEL:843"/>
+                                <option value="CIEL:102"/>
+                                <option value="CIEL:127750"/>
+                                <option value="CIEL:1754"/>
+                                <option value="CIEL:162853"/>
+                                <option value="CIEL:1434"/>
+                                <option value="CIEL:987"/>
+                                <option value="CIEL:1253"/>
+                                <option value="CIEL:1067"/>
+                                <option value="CIEL:5622"/>
+                            </orderProperty>
+                            <orderProperty name="discontinueReasonNonCoded"/>
+                        </div>
+                    </orderTemplate>
+                </drugOrder>
+            </div>
+        </section>
+    </includeIf>
+
+    <section id="id-treatment-art" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.arvTreatment">
         <div class="section-container-color">
-            <!-- this section is ONLY included for HIV intake encounter -->
-            <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d306a-40c4-11e7-a919-92ebcb67fe33'">
-                <h4>
-                    <uimessage code="pihcore.prophylaxis"/>
-                </h4>
-
-                <p>
-                    <!-- Added yes NOT 'not indicated' to toggle this section -->
-                    <obs conceptId="PIH:2740"
-                         answerConceptId="CIEL:1065"
-                         toggle="prophylaxisIndicated" />
-                </p>
-
-                <div style="overflow-x: scroll;">
-                     <table class="prophylaxisIndicated">
-                        <tr>
-                            <td>
-                                <label>
-                                    <uimessage code="pihcore.treatment" />
-                                </label>
-                            </td>
-                            <td>
-                                <label>
-                                    <uimessage code="pihcore.statusAndOrder" />
-                                </label>
-                            </td>
-                            <td>
-                                <label>
-                                    <uimessage code="pihcore.dosage" />
-                                </label>
-                            </td>
-                            <td>
-                            </td>
-                        </tr>
-
-                        <repeat>
-                            <template>
-                                <obsgroup groupingConceptId="PIH:Prescription construct">
-                                    <tr>
-                                        <td>
-                                            <!-- Medication orders -->
-                                            <obs conceptId="CIEL:1282" answerConceptId="{conceptMap}"
-                                                answerLabel="{drugname}"
-                                                toggle="{id: '{drugname}-treat', style: 'dim'}"/>
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <obs conceptId="PIH:PROPHYLAXIS STARTED"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.initiated" answerLabel=""
-                                                 toggle="{drugname}-start-date"/>
-                                            <obs conceptId="PIH:Prophylaxis should continue"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.continued" answerLabel="" />
-                                            <obs conceptId="PIH:Stop Rx" style="checkbox"
-                                                 answerConceptId="CIEL:1065"
-                                                 labelCode="pihcore.stopped" answerLabel=""
-                                                 toggle="{drugname}-reason-stopped"/>
-                                        </td>
-                                        <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded" />
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <p class="{drugname}-start-date">
-                                                <!-- Treatment start date -->
-                                                <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                     labelCode="pihcore.startDate" />
-                                            </p>
-                                            <p class="{drugname}-reason-stopped small-input">
-                                                <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                     labelCode="pihcore.stopReason" />
-                                            </p>
-                                        </td>
-                                    </tr>
-                                </obsgroup>
-                            </template>
-                            <render conceptMap="CIEL:105281" drugname="Cotrimoxazole" />
-                        </repeat>
-
-                        <repeat>
-                            <template>
-                                <obsgroup groupingConceptId="PIH:10742">
-                                    <tr>
-                                        <td>
-                                            <obs conceptId="CIEL:1282" answerConceptId="{conceptMap}"
-                                                answerLabel="{drugname}"
-                                                toggle="{id: '{drugname}-treat', style: 'dim'}"/>
-                                            <p class="radio {drugname}-treat">
-                                                <obs conceptId="PIH:13154" style="radio"
-                                                    answerConceptIds="CIEL:159943, CIEL:159944"
-                                                    answerSeparator="&lt;br /&gt;"/>
-                                            </p>
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <obs conceptId="PIH:PROPHYLAXIS STARTED"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.initiated" answerLabel=""
-                                                 toggle="{drugname}-start-date"/>
-                                            <obs conceptId="PIH:Prophylaxis should continue"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.continued" answerLabel="" />
-                                            <obs conceptId="PIH:Stop Rx" style="checkbox"
-                                                 answerConceptId="CIEL:1065"
-                                                 labelCode="pihcore.stopped" answerLabel=""
-                                                 toggle="{drugname}-reason-stopped"/>
-                                        </td>
-                                        <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded" />
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <p class="{drugname}-start-date">
-                                                <!-- Treatment start date -->
-                                                <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                     labelCode="pihcore.startDate" />
-                                            </p>
-                                            <p class="{drugname}-reason-stopped small-input">
-                                                <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                     labelCode="pihcore.stopReason" />
-                                            </p>
-                                        </td>
-                                    </tr>
-                                </obsgroup>
-                            </template>
-                            <render conceptMap="CIEL:78280"  drugname="Isoniazide" />
-                        </repeat>
-
-                        <repeat>
-                            <template>
-                                <obsgroup groupingConceptId="PIH:10742">
-                                    <tr>
-                                        <td>
-                                            <obs conceptId="CIEL:1282" answerConceptId="{conceptMap}"
-                                                answerLabel="{drugname}"
-                                                toggle="{id: '{drugname}-treat', style: 'dim'}"/>
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <obs conceptId="PIH:PROPHYLAXIS STARTED"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.initiated" answerLabel=""
-                                                 toggle="{drugname}-start-date"/>
-                                            <obs conceptId="PIH:Prophylaxis should continue"
-                                                 answerConceptId="CIEL:1065" style="checkbox"
-                                                 labelCode="pihcore.continued" answerLabel="" />
-                                            <obs conceptId="PIH:Stop Rx" style="checkbox"
-                                                 answerConceptId="CIEL:1065"
-                                                 labelCode="pihcore.stopped" answerLabel=""
-                                                 toggle="{drugname}-reason-stopped"/>
-                                        </td>
-                                        <td class="{drugname}-treat small-input">
-                                            <obs conceptId="PIH:Prescription instructions non-coded" />
-                                        </td>
-                                        <td class="{drugname}-treat">
-                                            <p class="{drugname}-start-date">
-                                                <!-- Treatment start date -->
-                                                <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                     labelCode="pihcore.startDate" />
-                                            </p>
-                                            <p class="{drugname}-reason-stopped small-input">
-                                                <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                     labelCode="pihcore.stopReason" />
-                                            </p>
-                                        </td>
-                                    </tr>
-                                </obsgroup>
-                            </template>
-                            <render conceptMap="CIEL:76488"  drugname="Fluconazole" />
-                            <render conceptMap="CIEL:74250"  drugname="Dapsone" />
-                        </repeat>
-
-                        <obsgroup groupingConceptId="PIH:10742">
-                            <tr>
-                                <td class="small-input">
-                                    <obs conceptId="CIEL:1282"
-                                        answerConceptId="PIH:3120" answerCode="pihcore.other"
-                                        toggle="{id: '{other-pro-treat}', style: 'dim'}"
-                                        commentFieldLabel="specify:" />
-                                </td>
-                                <td class="other-pro-treat">
-                                    <obs conceptId="PIH:PROPHYLAXIS STARTED"
-                                            answerConceptId="CIEL:1065" style="checkbox"
-                                            labelCode="pihcore.initiated" answerLabel=""
-                                            toggle="other-pro-start-date"/>
-                                    <obs conceptId="PIH:Prophylaxis should continue"
-                                            answerConceptId="CIEL:1065" style="checkbox"
-                                            labelCode="pihcore.continued" answerLabel="" />
-                                    <obs conceptId="PIH:Stop Rx" style="checkbox"
-                                            answerConceptId="CIEL:1065"
-                                            labelCode="pihcore.stopped" answerLabel=""
-                                            toggle="other-pro-reason-stopped"/>
-                                </td>
-                                <td class="other-pro-treat small-input">
-                                    <obs conceptId="PIH:Prescription instructions non-coded" />
-                                </td>
-                                <td class="other-pro-treat">
-                                    <p class="other-pro-start-date">
-                                        <!-- Treatment start date -->
-                                        <obs conceptId="CIEL:163526" allowFutureDates="true"
-                                                labelCode="pihcore.startDate" />
-                                    </p>
-                                    <p class="other-pro-reason-stopped small-input">
-                                        <obs conceptId="PIH:REASON TREATMENT STOPPED COMMENT"
-                                                labelCode="pihcore.stopReason" />
-                                    </p>
-                                </td>
-                            </tr>
-                        </obsgroup>
-                    </table>
-                </div>
-            </includeIf>
-
-            <!-- ARV Treatment -->
-            <h4>
-                <uimessage code="pihcore.arvTreatment"/>
-            </h4>
 
             <div class="two-columns">
                 <p class="radio">
@@ -736,45 +580,7 @@
                 </p>
             </div>
 
-            <label>
-                <b>
-                    <uimessage code="pihcore.artDrugOrders" />
-                </b>
-            </label>
-
-            <style type="text/css">
-                .order-field {
-                    display: inline-block;
-                    padding: 0px;
-                }
-                .order-field.action {
-                    display: block;
-                }
-                .order-field.dateActivated {
-                    padding-right: 20px;
-                }
-                .order-field-label {
-                    display: inline-block;
-                    padding-right: 5px;
-                    vertical-align: middle;
-                }
-                .order-field-label:after {
-                    content: "";
-                    white-space: pre;
-                }
-                .order-field-widget {
-                    display: inline-block;
-                }
-                .order-view-section {
-                    display: block;
-                    padding-left: 0px;
-                }
-                .hidden-field {
-                    display:none;
-                }
-            </style>
-
-            <drugOrder format="select">
+            <drugOrder>
                 <orderTemplate>
                     <orderProperty name="action"/>
                     <div style="padding:0px;">
@@ -869,41 +675,6 @@
                 </orderTemplate>
             </drugOrder>
 
-            <!-- Release Pre-drugOrder
-            <br/><br/>
-            <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d3312-40c4-11e7-a919-92ebcb67fe33'">
-                <label>
-                    <uimessage code="pihcore.ifChangeSpecifyReason" />
-                </label>
-                -->
-
-            <!-- Release Pre-drugOrder:  delete these lines too, but they don't like to be commented out
-                <div class="two-columns"> -->
-            <repeat>
-                        <template>
-                        <!-- Release Pre-drugOrder: Other ->
-                        <p>
-                            <obs conceptId="CIEL:1252" answerConceptId="{reason}" style="checkbox" />
-                        </p> -->
-                    </template>
-                <!-- Release Pre-drugOrder ->
-                <render reason="CIEL:843"    name="Failure" />
-                <render reason="CIEL:102"    name="Toxicity" />
-                <render reason="CIEL:162853" name="interaction" />
-                <render reason="CIEL:127750" name="refusal" />
-                <render reason="CIEL:1754"   name="stockOut" />
-                <render reason="CIEL:1434"   name="pregnant" /> -->
-                </repeat>
-
-                <!-- Release Pre-drugOrder: Other ->
-                <p>
-                    <obs conceptId="CIEL:1252" answerConceptId="CIEL:5622"
-                         style="checkbox" showCommentField="true" commentFieldLabel="" />
-                </p>
-                </div> -->
-
-            <!-- Release Pre-drugOrder </includeIf> -->
-
             <includeIf velocityTest="$patient.gender == 'F' ">
                 <br/>
                 <div class="two-columns">
@@ -924,12 +695,13 @@
                     </p>
                 </div>
             </includeIf>
+        </div>
 
-            <!-- TB Treatment -->
-            <br/>
-            <h4>
-                <uimessage code="pihcore.tbTreatment"/>
-            </h4>
+    </section>
+
+    <section id="id-treatment-tb" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.tbTreatment">
+        <div class="section-container-color">
+
             <div class="two-columns">
                 <p class="radio">
                     <label>
@@ -1008,12 +780,15 @@
                 </div>
             </includeIf>
 
-            <!-- STI screening for HIV followup -->
-            <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d3312-40c4-11e7-a919-92ebcb67fe33'">
-                <br/>
-                <h4>
-                    <uimessage code="pihcore.stiScreeningOnly"/>
-                </h4>
+        </div>
+
+    </section>
+
+    <!-- STI screening for HIV followup -->
+    <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d3312-40c4-11e7-a919-92ebcb67fe33'">
+        <section id="id-treatment-sti-screening" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.stiScreeningOnly">
+            <div class="section-container-color">
+
                 <div class="two-columns">
                     <repeat>
                         <template>
@@ -1035,154 +810,157 @@
                     </label>
                     <obs conceptId="PIH:1374" />
                 </div>
-            </includeIf>
+            </div>
+        </section>
+    </includeIf>
 
-        <!-- STI treatment -->
-        <h4>
-            <uimessage code="pihcore.stiTreatment"/>
-        </h4>
+    <!-- HIV intake only-->
+    <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d306a-40c4-11e7-a919-92ebcb67fe33'">
+        <section id="id-treatment-sti-treatment-intake" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.stiTreatment">
+            <div class="section-container-color">
+                <div class="two-columns">
+                    <p class="radio">
+                        <label>
+                            <uimessage code="pihcore.syph.needTreatment"/>
+                        </label>
+                        <br/>
 
-        <!-- HIV intake only-->
-        <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d306a-40c4-11e7-a919-92ebcb67fe33'">
-            <div class="two-columns">
-                <p class="radio">
+                        <obs conceptId="CIEL:165331" style="radio"
+                             answerConceptIds="PIH:2224,CIEL:1066,CIEL:1065,CIEL:160037"
+                             answerCodes="pihcore.ongoingExam,emr.no,emr.yes,pihcore.treatmentStarted"
+                             answerSeparator="&lt;br /&gt;"/>
+                    </p>
+
                     <label>
-                        <uimessage code="pihcore.syph.needTreatment"/>
+                        <uimessage code="pihcore.startDate"/>
                     </label>
+                    <obs conceptId="PIH:13023"/>
+
                     <br/>
+                    <br/>
+                    <br/>
+                    <p>
+                        <label>
+                            <uimessage code="pihcore.syph.patientNeedsOtherTreatment"/>
+                        </label>
+                        <table>
+                            <tr>
+                                <td>
+                                    <label>
+                                        <uimessage code="pihcore.regimen"/>
+                                    </label>
+                                </td>
+                                <td>
+                                    <label>
+                                        <uimessage code="providermanagement.startDate"/>
+                                    </label>
+                                </td>
+                            </tr>
 
-                    <obs conceptId="CIEL:165331" style="radio"
-                         answerConceptIds="PIH:2224,CIEL:1066,CIEL:1065,CIEL:160037"
-                         answerCodes="pihcore.ongoingExam,emr.no,emr.yes,pihcore.treatmentStarted"
-                         answerSeparator="&lt;br /&gt;"/>
-                </p>
-
-                <label>
-                    <uimessage code="pihcore.startDate"/>
-                </label>
-                <obs conceptId="PIH:13023"/>
-
-                <br/>
-                <br/>
-                <br/>
+                            <repeat with="['1'],['2'],['3']">
+                                <obsgroup groupingConceptId="PIH:13027">
+                                    <tr>
+                                        <td>
+                                            <!-- Toggle doesn't work with text -->
+                                            <obs conceptId="PIH:10637" style="text"/>
+                                        </td>
+                                        <td>
+                                            <obs conceptId="CIEL:1428"/>
+                                        </td>
+                                    </tr>
+                                </obsgroup>
+                            </repeat>
+                        </table>
+                    </p>
+                </div>
                 <p>
                     <label>
-                        <uimessage code="pihcore.syph.patientNeedsOtherTreatment"/>
+                        <uimessage code="pihcore.remarks"/>
                     </label>
-                    <table>
-                        <tr>
-                            <td>
-                                <label>
-                                    <uimessage code="pihcore.regimen"/>
-                                </label>
-                            </td>
-                            <td>
-                                <label>
-                                    <uimessage code="providermanagement.startDate"/>
-                                </label>
-                            </td>
-                        </tr>
-
-                        <repeat with="['1'],['2'],['3']">
-                            <obsgroup groupingConceptId="PIH:13027">
-                                <tr>
-                                    <td>
-                                        <!-- Toggle doesn't work with text -->
-                                        <obs conceptId="PIH:10637" style="text"/>
-                                    </td>
-                                    <td>
-                                        <obs conceptId="CIEL:1428"/>
-                                    </td>
-                                </tr>
-                            </obsgroup>
-                        </repeat>
-                    </table>
+                    <obs conceptId="PIH:1374" style="text" rows="2" cols="40"/>
                 </p>
             </div>
-            <p>
+        </section>
+    </includeIf>
+
+    <!-- HIV followup only-->
+    <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d3312-40c4-11e7-a919-92ebcb67fe33'">
+        <section id="id-treatment-sti-treatment-followup" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.stiTreatment">
+            <div class="section-container-color">
                 <label>
-                    <uimessage code="pihcore.remarks"/>
+                    <uimessage code="pihcore.syph.needTreatment"/>
                 </label>
-                <obs conceptId="PIH:1374" style="text" rows="2" cols="40"/>
-            </p>
-        </includeIf>
+                <p class="small">
+                    <obs id="syph-treatment-need"
+                         conceptId="CIEL:165331" style="radio"
+                         answerConceptIds="CIEL:1065,CIEL:1066"
+                         answerCodes="emr.yes,emr.no"
+                         answerSeparator="">
+                        <controls>
+                            <when value="CIEL:1065" thenDisplay="#start-date-syph-treatment"/>
+                        </controls>
+                    </obs>
+                </p>
 
-        <!-- HIV followup only-->
-        <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d3312-40c4-11e7-a919-92ebcb67fe33'">
-            <label>
-                <uimessage code="pihcore.syph.needTreatment"/>
-            </label>
-            <p class="small">
-                <obs id="syph-treatment-need"
-                     conceptId="CIEL:165331" style="radio"
-                     answerConceptIds="CIEL:1065,CIEL:1066"
-                     answerCodes="emr.yes,emr.no"
-                     answerSeparator="">
-                    <controls>
-                        <when value="CIEL:1065" thenDisplay="#start-date-syph-treatment"/>
-                    </controls>
-                </obs>
-            </p>
-
-            <div id="start-date-syph-treatment">
-                <label>
-                    <uimessage code="pihcore.ifYesStartDate"/>
-                </label>
-                <obs conceptId="PIH:13023"/>
-            </div>
-
-            <!--Other STD -->
-            <label>
-                <uimessage code="pihcore.treatmentNeededOtherSTI"/>?
-            </label>
-            <p class="small">
-                <obs id="other-sti-treatment-need"
-                     conceptId="PIH:13077" style="radio"
-                     answerConceptIds="CIEL:1065,CIEL:1066"
-                     answerSeparator="">
-                    <controls>
-                        <when value="CIEL:1065" thenDisplay="#other-sti-details"/>
-                    </controls>
-                </obs>
-            </p>
-
-            <div id="other-sti-details">
-                <obsgroup groupingConceptId="PIH:13027">
+                <div id="start-date-syph-treatment">
                     <label>
-                        <uimessage code="pihcore.mch.otherSTI" />
+                        <uimessage code="pihcore.ifYesStartDate"/>
                     </label>
-                    <repeat>
-                        <template>
-                            <p>
-                                <obs conceptId="PIH:13076"
-                                     answerConceptId="{stiDiag}"
-                                     style="checkbox"/>
-                            </p>
-                        </template>
-                        <render stiDiag="PIH:7247" comment="Chlamydia"/>
-                        <render stiDiag="CIEL:117767" comment="Gonorrhea"/>
-                        <render stiDiag="CIEL:117829" comment="GenitalHerpes"/>
-                        <render stiDiag="CIEL:1213" comment="HPV"/>
-                        <render stiDiag="CIEL:111759" comment="HepB"/>
-                    </repeat>
+                    <obs conceptId="PIH:13023"/>
+                </div>
 
-                    <p>
-                        <obs conceptId="PIH:13076"
-                             answerConceptId="CIEL:5622"
-                             style="checkbox" showCommentField="true" commentFieldLabel=""/>
-                    </p>
+                <!--Other STD -->
+                <label>
+                    <uimessage code="pihcore.treatmentNeededOtherSTI"/>?
+                </label>
+                <p class="small">
+                    <obs id="other-sti-treatment-need"
+                         conceptId="PIH:13077" style="radio"
+                         answerConceptIds="CIEL:1065,CIEL:1066"
+                         answerSeparator="">
+                        <controls>
+                            <when value="CIEL:1065" thenDisplay="#other-sti-details"/>
+                        </controls>
+                    </obs>
+                </p>
 
-                    <p class="narrow">
+                <div id="other-sti-details">
+                    <obsgroup groupingConceptId="PIH:13027">
                         <label>
-                            <uimessage code="pihcore.startDate"/>
+                            <uimessage code="pihcore.mch.otherSTI" />
                         </label>
-                        <obs conceptId="CIEL:1428"/>
-                    </p>
-                </obsgroup>
+                        <repeat>
+                            <template>
+                                <p>
+                                    <obs conceptId="PIH:13076"
+                                         answerConceptId="{stiDiag}"
+                                         style="checkbox"/>
+                                </p>
+                            </template>
+                            <render stiDiag="PIH:7247" comment="Chlamydia"/>
+                            <render stiDiag="CIEL:117767" comment="Gonorrhea"/>
+                            <render stiDiag="CIEL:117829" comment="GenitalHerpes"/>
+                            <render stiDiag="CIEL:1213" comment="HPV"/>
+                            <render stiDiag="CIEL:111759" comment="HepB"/>
+                        </repeat>
+
+                        <p>
+                            <obs conceptId="PIH:13076"
+                                 answerConceptId="CIEL:5622"
+                                 style="checkbox" showCommentField="true" commentFieldLabel=""/>
+                        </p>
+
+                        <p class="narrow">
+                            <label>
+                                <uimessage code="pihcore.startDate"/>
+                            </label>
+                            <obs conceptId="CIEL:1428"/>
+                        </p>
+                    </obsgroup>
+                </div>
             </div>
-        </includeIf>
-        </div>
-    </section>
+        </section>
+    </includeIf>
 
     <!-- this section is ONLY included for HIV intake encounter -->
     <includeIf velocityTest="$encounter.encounterType.uuid == 'c31d306a-40c4-11e7-a919-92ebcb67fe33' &amp;&amp; ($patient.getAge($encounter.getEncounterDatetime()) &gt; 13)">

--- a/configuration/pih/htmlforms/hiv/section-hiv-plan.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-plan.xml
@@ -485,6 +485,12 @@
         <section id="id-treatment-prophylaxis" sectionTag="fieldset" headerTag="legend" headerStyle="title" headerCode="pihcore.prophylaxis">
             <div class="section-container-color">
 
+                <p class="radio">
+                    <obs conceptId="PIH:13154" style="radio"
+                         answerConceptIds="CIEL:159943, CIEL:159944"
+                         labelCode="pihcore.inhTreatmentLine"/>
+                </p>
+
                 <drugOrder>
                     <orderTemplate>
                         <orderProperty name="action"/>


### PR DESCRIPTION
This is ready for review.  Feel free to just merge in if it'll be easier to review and test once on the test server.  This does the following:

* Replaces the prophylaxis section with a drug order tag, supporting the same orderables, minus the "other" option
* Removes the example lab order section that I had added a while back as a demonstration
* Organizes each of the order categories into sections, as it was getting hard to distinguish them - to me this looks better

We likely want to to an overhaul to the UI/UX of the drug ordering tags in general, but leaving that for a different ticket, as we will want to mock something specific up.

![image](https://user-images.githubusercontent.com/356297/112385075-8ef81100-8cc5-11eb-8a96-c8af3e628117.png)
