### PR TITLE
UHM-5695 Add family planning section to PMTCT history

### DIFF
--- a/configuration/pih/htmlforms/hiv/section-pmtct-history.xml
+++ b/configuration/pih/htmlforms/hiv/section-pmtct-history.xml
@@ -14,6 +14,11 @@
                 display: inline-block;
             }
 
+            form input[type="radio"], .form input[type="radio"] {
+                float: none;
+                display: inline-block;
+            }
+
             .two-columns-o {
                 column-count: 2;
                 -webkit-column-count: 2;
@@ -1035,89 +1040,61 @@
                 </tr>
 
             </table>
-
-                <h3>
-                    <uimessage code="pihcore.familyPlanningHistory.title"/>
-                </h3>
-                <table>
-                    <tr>
-                        <td>
-                            <label>
-                                <uimessage code="pihcore.familyPlanning.method"/>
-                            </label>
-                        </td>
-                        <td>
-                            <label>
-                                <uimessage code="pihcore.startDate"/>
-                            </label>
-                        </td>
-                        <td>
-                            <label>
-                                <uimessage code="pihcore.endDate"/>
-                            </label>
-                        </td>
-                    </tr>
-
-                    <repeat>
-                        <template>
-                            <obsgroup groupingConceptId="PIH:Family planning history construct">
-                                <tr>
-                                    <td id="{comment}-fp">
-                                        <obs conceptId="CIEL:374"
-                                             answerConceptId="{fpMethod}"
-                                             style="checkbox"
-                                             toggle="{id: '{comment}-date', style: 'dim'}"
-                                        />
-                                    </td>
-                                    <td class="{comment}-date">
-                                        <obs conceptId="CIEL:163757"/>
-                                    </td>
-                                    <td class="{comment}-date">
-                                        <obs conceptId="CIEL:163758" allowFutureDates="true"/>
-                                    </td>
-                                </tr>
-                            </obsgroup>
-                        </template>
-                        <render fpMethod="CIEL:780" comment="Pill"/>
-                        <render fpMethod="CIEL:907" comment="Depo-provera"/>
-                        <render fpMethod="CIEL:190" comment="Condoms"/>
-                        <render fpMethod="CIEL:78796" comment="Norplant"/>
-                        <render fpMethod="CIEL:5275" comment="IUD"/>
-                        <render fpMethod="CIEL:1472" comment="TubalLigation"/>
-                        <render fpMethod="CIEL:1489" comment="Vasectomy"/>
-                    </repeat>
-
-                    <!-- Other family planning -->
-                    <obsgroup groupingConceptId="PIH:Family planning history construct">
-                        <tr>
-                            <td>
-                                <obs conceptId="CIEL:374"
-                                     answerConceptId="CIEL:5622"
-                                     style="checkbox"
-                                     toggle="{id: 'other-fp', style: 'dim'}"
-                                />
-                            </td>
-                            <td class="other-fp">
-                                <obs conceptId="CIEL:163757"/>
-                            </td>
-                            <td class="other-fp">
-                                <obs conceptId="CIEL:163758" allowFutureDates="true"/>
-                            </td>
-                        </tr>
-                    </obsgroup>
-                    <tr>
-                        <td align="right" class="other-fp">
-                            <label>
-                                <uimessage code="zl.ifOtherSpecify"/>
-                            </label>
-                            <obs conceptId="PIH:2996" size="30"/>
-                        </td>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                </table>
         </div>
     </section>
+
+    <section id="family-plan-section" sectionTag="fieldset" headerTag="legend"
+             headerStyle="title" headerCode="pihcore.familyPlanning.title">
+
+        <div id="fp-area" class="section-container">
+            <div class="two-columns">
+                <div>
+                    <obs conceptId="CIEL:163560" style="checkbox"
+                         answerConceptId="CIEL:1382" answerCode="pihcore.mch.counselling.familyPlanning" />
+                </div>
+                <div>
+                    <obs conceptId="CIEL:965" style="checkbox"
+                         answerConceptId="CIEL:1065" answerCode="pihcore.currentlyUsing"/>
+                </div>
+            </div>
+            <br/>
+
+            <p class="side-by-side">
+                <label>
+                    <uimessage code="pihcore.fpMethod"/>:
+                </label>
+                <br/>
+                <obsgroup groupingConceptId="PIH:Family planning construct">
+                    <obs conceptId="CIEL:374"
+                         answerConceptIds="CIEL:159783,CIEL:80784,CIEL:5277,CIEL:190,CIEL:907,CIEL:5275,CIEL:1873,CIEL:1472,CIEL:136163"
+                         answerCodes="COC,COP,pihcore.fp.rhythm,Condoms,Depo-provera,pihcore.fp.iud,Implant,pihcore.fp.tubalLig,pihcore.fp.breast"
+                         style="radio" />
+                    <div class="two-columns">
+                        <div>
+                            <label>
+                                <uimessage code="pihcore.startDate"/>:
+                            </label>
+                            <obs conceptId="CIEL:163757" />
+                        </div>
+                        <div>
+                            <label>
+                                <uimessage code="pihcore.endDate"/>:
+                            </label>
+                            <obs conceptId="CIEL:163758" />
+                        </div>
+                    </div>
+                </obsgroup>
+            </p>
+
+            <p>
+                <label>
+                    <uimessage code="pihcore.dateImplant"/>:
+                </label>
+                <obs conceptId="PIH:3203" />
+            </p>
+        </div>
+    </section>
+
 
     <section id="presenting-history" sectionTag="fieldset" headerTag="legend" headerStyle="title"
              headerCode="pihcore.history.presentingHistory.title">


### PR DESCRIPTION
The other PR had conflicts to be resolved.  It included gestational age calculations, reformatting, and contacts.  @louidorjp Hope it's ok to just add this one section and remove the old one.

Apologies that I missed this earlier...

FYI @brandones  