### PR TITLE
UHM-5813

### DIFF
--- a/configuration/messageproperties/messages_zl_en.properties
+++ b/configuration/messageproperties/messages_zl_en.properties
@@ -1,0 +1,3 @@
+zl.completeFormsQuestions=Completed Forms
+zl.ARVConsentFormSigned=ART consent form signed?
+zl.locationFormComplete=Location form completed?

--- a/configuration/messageproperties/messages_zl_fr.properties
+++ b/configuration/messageproperties/messages_zl_fr.properties
@@ -1,0 +1,3 @@
+zl.completeFormsQuestions=Formulaires remplis
+zl.ARVConsentFormSigned=Formulaire de consentement ARV signé?
+zl.locationFormComplete=Formulaire de localisation rempli?

--- a/configuration/messageproperties/messages_zl_ht.properties
+++ b/configuration/messageproperties/messages_zl_ht.properties
@@ -1,0 +1,3 @@
+zl.completeFormsQuestions=Formulaires remplis
+zl.ARVConsentFormSigned=Formulaire de consentement ARV signé?
+zl.locationFormComplete=Formulaire de localisation rempli?

--- a/configuration/pih/htmlforms/hiv/section-hiv-history.xml
+++ b/configuration/pih/htmlforms/hiv/section-hiv-history.xml
@@ -173,19 +173,19 @@
     -->
 
     <section id="complete-forms-questions-section" sectionTag="fieldset" headerTag="legend" headerStyle="title"
-             headerCode="pihcore.completeFormsQuestions">
+             headerCode="zl.completeFormsQuestions">
         <div class="section-container-color">
             <div id="complete-forms-questions-section-details">
                     <p class="side-by-side">
                         <obs id="arv-form-signed"
                              conceptId="PIH:ARV CONSENT FORM SIGNED" style="radio"
-                             labelCode="pihcore.ARVConsentFormSigned"
+                             labelCode="zl.ARVConsentFormSigned"
                              answerSeparator=""/>
                     </p>
                     <p class="side-by-side">
                         <obs id="location-form-complete"
                              conceptId="PIH:LOCATION FORM COMPLETED" style="radio"
-                             labelCode="pihcore.locationFormComplete"
+                             labelCode="zl.locationFormComplete"
                              answerSeparator=""/>
                     </p>
             </div>


### PR DESCRIPTION

This provides translation codes for the two new questions added the form in Louidor's previous commit for UHM-5813.

Note that since these are questions specific to Haiti, I took this opportunity to test out providing a "ZL-only" messages.properties within the config-zl project.  It seems to work fine.  You can see the naming convention I used (if I just called it messages_en.properties, I believe it would *overwrite* the messages provided by config-pihemr, which we don't want), and we could follow this for other countries as needed (though it may not be needed if all other countries are operating in a single language).

Note that since we are likely going to be moving away from Transifex, I did not add these resources to Transifex... we can go ahead and commit directly to these files.

Also note that for some reason, if I didn't include a messages_zl_ht.properties file, then when in the Kreyol locale, it did not fall back to either English or French, but just rendered the raw message codes.  This seems like a bug we should look into, but, for now, I just included the French translations in Kreyol messages.properties, since we want to "fall back" to French when operating in the Kreyol locale.

Thoughts @rjacques89  @louidorjp  @mseaton @brandones @cioan 

