### PR TITLE
Remove SPA Preview from ZL servers

### DIFF
--- a/configuration/pih/pih-config-mirebalais-humci.json
+++ b/configuration/pih/pih-config-mirebalais-humci.json
@@ -50,7 +50,6 @@
     "rehab",
     "relationships",
     "socioEconomics",
-    "spaPreview",
     "surgery",
     "systemAdministration",
     "uhmVitals",


### PR DESCRIPTION
In order to reduce the possibility of disrupting the J9 app. https://pihemr.atlassian.net/browse/UHM-6171