### PR TITLE
Add ignoreStatusCodes to deployment actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400
 
     - name: Deploy to ci
       uses: fjogeleit/http-request-action@v1
@@ -51,6 +52,7 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400
 
     - name: Deploy to haitihivtest
       uses: fjogeleit/http-request-action@v1
@@ -61,6 +63,7 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400
 
     - name: Deploy to zl-ci
       uses: fjogeleit/http-request-action@v1
@@ -71,3 +74,4 @@ jobs:
         customHeaders: '{"Accept": "application/json"}'
         retry: 60
         retryWait: 60000
+        ignoreStatusCodes: 400


### PR DESCRIPTION
Added ignoreStatusCodes option to multiple deployment steps to prevent a hang when a bamboo job is disabled.