### PR TITLE
HAI-1205: Segregate Monitoring Reports by Location

### DIFF
--- a/configuration/reports/reportdescriptors/dataexports/accounting.yml
+++ b/configuration/reports/reportdescriptors/dataexports/accounting.yml
@@ -9,6 +9,11 @@ parameters:
   - key: "endDate"
     type: "java.util.Date"
     label: "reporting.parameter.endDate"
+  - key: "location"
+    type: "org.openmrs.Location"
+    label: "reporting.parameter.location"
+    widgetConfiguration:
+     withTag: "Visit Location"
 datasets:
   - key: "accounting"
     type: "sql"

--- a/configuration/reports/reportdescriptors/dataexports/chronicMaladies.yml
+++ b/configuration/reports/reportdescriptors/dataexports/chronicMaladies.yml
@@ -9,6 +9,11 @@ parameters:
   - key: "endDate"
     type: "java.util.Date"
     label: "reporting.parameter.endDate"
+  - key: "location"
+    type: "org.openmrs.Location"
+    label: "reporting.parameter.location"
+    widgetConfiguration:
+     withTag: "Visit Location"
 datasets:
   - key: "chronicMaladies"
     type: "sql"

--- a/configuration/reports/reportdescriptors/dataexports/mspp.yml
+++ b/configuration/reports/reportdescriptors/dataexports/mspp.yml
@@ -9,6 +9,11 @@ parameters:
   - key: "endDate"
     type: "java.util.Date"
     label: "reporting.parameter.endDate"
+  - key: "location"
+    type: "org.openmrs.Location"
+    label: "reporting.parameter.location"
+    widgetConfiguration:
+     withTag: "Visit Location"
 datasets:
   - key: "msppReport"
     type: "sql"

--- a/configuration/reports/reportdescriptors/dataexports/newDiseaseEpisodies.yml
+++ b/configuration/reports/reportdescriptors/dataexports/newDiseaseEpisodies.yml
@@ -9,6 +9,11 @@ parameters:
   - key: "endDate"
     type: "java.util.Date"
     label: "reporting.parameter.endDate"
+  - key: "location"
+    type: "org.openmrs.Location"
+    label: "reporting.parameter.location"
+    widgetConfiguration:
+     withTag: "Visit Location"
 datasets:
   - key: "newDiseaseEpisodes"
     type: "sql"

--- a/configuration/reports/reportdescriptors/dataexports/sql/accounting.sql
+++ b/configuration/reports/reportdescriptors/dataexports/sql/accounting.sql
@@ -4,48 +4,60 @@ SET @endDate = ADDDATE(@endDate, INTERVAL 1 DAY);
 
 select cn.name "Catégorie", CEIL(sum(o.value_numeric)) "Montant" from
 obs o
-INNER JOIN obs os on os.encounter_id = o.encounter_id and os.voided = 0 and os.concept_id = 
-    (select concept_id from report_mapping where source = 'PIH' and code = 'Type of HUM visit') 
-LEFT OUTER JOIN concept_name cn on cn.concept_id = os.value_coded and cn.locale = 'fr' and cn.locale_preferred = '1'  and cn.voided = 0    
+INNER JOIN obs os on os.encounter_id = o.encounter_id and os.voided = 0 and os.concept_id =
+    (select concept_id from report_mapping where source = 'PIH' and code = 'Type of HUM visit')
+LEFT OUTER JOIN concept_name cn on cn.concept_id = os.value_coded and cn.locale = 'fr' and cn.locale_preferred = '1'  and cn.voided = 0
+INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 where 1=1
 and o.voided = 0
-and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount') 
+and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount')
 AND date(o.obs_datetime) >=  @startDate
 AND date(o.obs_datetime) <  @endDate
+AND v.location_id = @location
 group by cn.name
 UNION ALL
-select ' ',' ' 
+select ' ',' '
 UNION ALL
   select 'Total pour cette période', CEIL(sum(o.value_numeric)) "Montant" from
 obs o
+INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 where 1=1
 and o.voided = 0
-and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount') 
+and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount')
 AND date(o.obs_datetime) >=  @startDate
 AND date(o.obs_datetime) < @endDate
+AND v.location_id = @location
 UNION ALL
-select ' ',' ' 
+select ' ',' '
 UNION ALL
 select 'Nombre de patients exonérés', CEIL(count(o.person_id)) from
 obs o
+INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 where 1=1
 and o.voided = 0
-and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount') 
+and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount')
 and o.value_numeric = 0
 AND date(o.obs_datetime) >=  @startDate
 AND date(o.obs_datetime) < @endDate
+AND v.location_id = @location
 UNION ALL
-select ' ',' ' 
+select ' ',' '
 UNION ALL
 select 'Nombre de patients ayant payés plus déune fois', CEIL(count(o.person_id)) from
 obs o
+INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 where 1=1
 and o.voided = 0
-and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount') 
+and o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'Payment amount')
 and o.value_numeric > 0
 AND date(o.obs_datetime) >=  @startDate
 AND date(o.obs_datetime) < @endDate
-and exists  
+AND v.location_id = @location
+and exists
   (select 1 from obs o2 
   where o2.obs_id <> o.obs_id
   and o2.concept_id = o.concept_id

--- a/configuration/reports/reportdescriptors/dataexports/sql/chronicMaladies.sql
+++ b/configuration/reports/reportdescriptors/dataexports/sql/chronicMaladies.sql
@@ -84,6 +84,7 @@ select
 (CASE when round(DATEDIFF(o.obs_datetime, pr.birthdate)/365.25, 1) > 50 then 1 else 0 end) "G50"
 from obs o
 INNER JOIN encounter e on e.encounter_id = o.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person pr on pr.person_id = o.person_id
 INNER JOIN report_mapping rm on o.value_coded = rm.concept_id
 LEFT OUTER JOIN obs o_prev on o_prev.person_id = o.person_id and o_prev.value_coded = o.value_coded and o_prev.obs_id < o.obs_id
@@ -93,6 +94,7 @@ and (o.concept_id = (select concept_id from report_mapping where source = 'PIH' 
 and o.voided = 0
 AND date(o.obs_datetime) >= @startDate
 AND date(o.obs_datetime) < @endDate
+AND v.location_id = @location
 group by o.obs_id, rm.source, rm.code
 union all
 select
@@ -104,6 +106,7 @@ select
 (CASE when round(DATEDIFF(e_vitals.encounter_datetime, pr.birthdate)/365.25, 1) >= 25 and round(DATEDIFF(e_vitals.encounter_datetime, pr.birthdate)/365.25, 1) <50 then 1 else 0 end) "L50",
 (CASE when round(DATEDIFF(e_vitals.encounter_datetime, pr.birthdate)/365.25, 1) > 50 then 1 else 0 end) "G50"
 from encounter e_vitals
+INNER JOIN visit v_vitals ON e_vitals.visit_id = v_vitals.visit_id AND v_vitals.voided = 0
 INNER JOIN person pr on pr.person_id = e_vitals.patient_id
 INNER JOIN report_mapping rm_syst on rm_syst.code = 'SYSTOLIC BLOOD PRESSURE' and rm_syst.source = 'PIH'
 INNER JOIN report_mapping rm_diast on rm_diast.code = 'DIASTOLIC BLOOD PRESSURE' and rm_diast.source = 'PIH'
@@ -120,6 +123,7 @@ LEFT OUTER JOIN
 where e_vitals.voided = 0
 AND date(e_vitals.encounter_datetime) >= @startDate
 AND date(e_vitals.encounter_datetime) < @endDate
+AND v_vitals.location_id = @location
 and e_vitals.encounter_type in (select et.encounter_type_id from encounter_type et where et.name = 'Signes vitaux')
 order by Diagnosis desc
 ) tab on dx.maladies = tab.Diagnosis and dx.newold = tab.recurrent

--- a/configuration/reports/reportdescriptors/dataexports/sql/msppReport.sql
+++ b/configuration/reports/reportdescriptors/dataexports/sql/msppReport.sql
@@ -37,6 +37,7 @@ FROM (
        DISTINCT e.patient_id,
         TIMESTAMPDIFF(YEAR, pr.birthdate, e.encounter_datetime) AS age
     FROM encounter e
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN patient p ON e.patient_id = p.patient_id AND p.voided = 0
     INNER JOIN person pr ON pr.person_id = p.patient_id AND pr.voided = 0
 
@@ -51,10 +52,11 @@ FROM (
         ON e.patient_id = first_visit.patient_id
         AND e.encounter_datetime = first_visit.first_visit_this_year
 
-    WHERE e.voided = 0 
+    WHERE e.voided = 0
     AND e.encounter_type = encounter_type('55a0d3ea-a4d7-4e88-8f01-5aceb2d3c61b')
     AND DATE(e.encounter_datetime) >= @firstDate
     AND DATE(e.encounter_datetime) < @endDate
+    AND v.location_id = @location
 ) t;
 
 -- Subsequent visits 
@@ -82,10 +84,11 @@ FROM (
     INNER JOIN person pr 
         ON p.patient_id = pr.person_id AND pr.voided = 0
 
-    INNER JOIN encounter e 
-        ON p.patient_id = e.patient_id 
-        AND e.voided = 0 
+    INNER JOIN encounter e
+        ON p.patient_id = e.patient_id
+        AND e.voided = 0
         AND e.encounter_type = encounter_type('55a0d3ea-a4d7-4e88-8f01-5aceb2d3c61b')
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
         SELECT patient_id, MIN(encounter_datetime) AS first_visit_this_year
         FROM encounter
@@ -93,7 +96,7 @@ FROM (
         AND voided = 0
         AND YEAR(encounter_datetime) = YEAR(CURDATE())
         GROUP BY patient_id
-    ) first_visit 
+    ) first_visit
         ON e.patient_id = first_visit.patient_id
 
     WHERE p.voided = 0
@@ -102,6 +105,7 @@ FROM (
 
     AND DATE(e.encounter_datetime) >= @startDate
     AND DATE(e.encounter_datetime) < @endDate
+    AND v.location_id = @location
 
     AND p.patient_id NOT IN (
         SELECT person_id 
@@ -118,6 +122,7 @@ SELECT
     COUNT(*)
    INTO @pregnant_visits_n
 FROM encounter e
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN (
     SELECT
         e.encounter_id
@@ -158,7 +163,8 @@ INNER JOIN (
 ) last_encounters
     ON last_encounters.encounter_id = e.encounter_id
     WHERE  e.encounter_datetime >= @startDate
-	AND e.encounter_datetime <  @endDate;
+	AND e.encounter_datetime <  @endDate
+	AND v.location_id = @location;
 
 
 -- Subsequent visits for pregnancy women
@@ -171,6 +177,7 @@ FROM (
         DATE(fs.encounter_datetime) AS visit_date
 
     FROM encounter fs
+    INNER JOIN visit v_fs ON fs.visit_id = v_fs.visit_id AND v_fs.voided = 0
 
     INNER JOIN obs o_suivi
         ON o_suivi.encounter_id = fs.encounter_id
@@ -183,7 +190,7 @@ FROM (
         AND o_pn.concept_id  = concept_from_mapping('PIH', '8879')
         AND o_pn.value_coded = concept_from_mapping('PIH', '6259')
         AND o_pn.voided = 0
-        
+
     WHERE fs.voided = 0
     AND NOT EXISTS (
         SELECT 1
@@ -202,9 +209,10 @@ FROM (
           AND DATE(e_new.encounter_datetime) = DATE(fs.encounter_datetime)
           AND e_new.voided = 0
     )
-    
+
     AND fs.encounter_datetime >= @startDate
     AND fs.encounter_datetime < @endDate
+    AND v_fs.location_id = @location
 
     GROUP BY fs.patient_id, DATE(fs.encounter_datetime)
 
@@ -215,6 +223,7 @@ SELECT
        COUNT(*)
    INTO @clientPfN
 FROM encounter e
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN (
     SELECT
         e.encounter_id
@@ -255,7 +264,8 @@ INNER JOIN (
 ) last_encounters
     ON last_encounters.encounter_id = e.encounter_id
     WHERE  e.encounter_datetime >= @startDate
-	AND e.encounter_datetime <  @endDate;
+	AND e.encounter_datetime <  @endDate
+	AND v.location_id = @location;
 
 
 -- SUBSEQUENT CLIENT PF
@@ -268,6 +278,7 @@ FROM (
         DATE(fs.encounter_datetime) AS visit_date
 
     FROM encounter fs
+    INNER JOIN visit v_fs ON fs.visit_id = v_fs.visit_id AND v_fs.voided = 0
 
     INNER JOIN obs o_suivi
         ON o_suivi.encounter_id = fs.encounter_id
@@ -303,6 +314,7 @@ FROM (
     )
     AND fs.encounter_datetime >= @startDate
     AND fs.encounter_datetime < @endDate
+    AND v_fs.location_id = @location
 
     GROUP BY fs.patient_id, DATE(fs.encounter_datetime)
 
@@ -316,10 +328,12 @@ from
 obs o 
 INNER JOIN encounter e 
 ON o.encounter_id =e.encounter_id  
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 WHERE o.value_coded =concept_from_mapping('PIH','7202')
 AND o.voided =0
 AND date(e.encounter_datetime) >= @startDate
 AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location
 GROUP BY e.patient_id, DATE(e.encounter_datetime);
 
 -- EXAMEN LABORATOIRE
@@ -330,9 +344,12 @@ CREATE TEMPORARY TABLE pregnancy_patient_temp(person_id int,pregnant int);
    SELECT
     o.person_id, IF(DATE(o.value_datetime) > CURDATE(), 1, 0)
     FROM obs o
+    INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     WHERE o.concept_id = concept_from_mapping('PIH', '5596')
     AND o.voided = 0
     AND DATE(o.value_datetime) > CURDATE()
+    AND v.location_id = @location
     GROUP BY o.person_id;
 
 
@@ -341,6 +358,7 @@ SELECT COUNT(*) INTO @total_urine_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -350,7 +368,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', '12375')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
 
 
 -- TOTAL TEST D'HEMOGRAME
@@ -358,6 +377,7 @@ SELECT COUNT(*) INTO @total_hemogram_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -367,7 +387,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', '11711')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
 
  -- TOTAL TEST MALARIA TEST RAPID
@@ -375,6 +396,7 @@ SELECT COUNT(*) INTO @totat_malaria_rapd_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -384,13 +406,15 @@ WHERE o.concept_id = concept_from_mapping('PIH', '11464')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
   -- TOTAL TEST RPR
 SELECT COUNT(*) INTO @total_rpr_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -400,7 +424,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', 'RPR')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
  
   -- TOTAL TEST  HIV
@@ -408,6 +433,7 @@ SELECT COUNT(*) INTO @total_hiv_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -417,13 +443,15 @@ WHERE o.concept_id = concept_from_mapping('PIH', '1040')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
   -- TOTAL SICKLING TEST
 SELECT COUNT(*) INTO @total_sickling_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -433,7 +461,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', '12716')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
  
   -- TOTAL TEST GROUPE SANGUIN
@@ -441,6 +470,7 @@ SELECT COUNT(*) INTO @total_blood_type_test_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -450,7 +480,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', 'BLOOD TYPING')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
    
  
 
@@ -461,13 +492,15 @@ SELECT COUNT(*) INTO @total_blood_type_test
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.concept_id = concept_from_mapping('PIH', 'BLOOD TYPING')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
   -- TOTAL SICKLING TEST NOT PREGNANT
 SELECT COUNT(*) 
@@ -475,12 +508,14 @@ INTO @total_sickling_test
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.concept_id = concept_from_mapping('PIH', '12716')
   AND o.voided = 0 
   AND e.voided = 0
-  AND date(e.encounter_datetime) >= @startDate;
+  AND date(e.encounter_datetime) >= @startDate
+  AND v.location_id = @location;
 
   
   
@@ -491,13 +526,15 @@ INTO @total_malaria_rapd_test
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.concept_id = concept_from_mapping('PIH', '11464')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
 
 
 
@@ -507,6 +544,7 @@ SELECT COUNT(*) INTO @totat_malaria_rapd_test_positif
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.concept_id = concept_from_mapping('PIH', '11464')
@@ -514,7 +552,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', '11464')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
  
  -- TOTAL TEST MALARIA TEST RAPID POSITIVE
@@ -522,6 +561,7 @@ SELECT COUNT(*) INTO @totat_malaria_rapd_test_positif_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -532,13 +572,15 @@ WHERE o.concept_id = concept_from_mapping('PIH', '11464')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
   -- TOTAL TEST RPR POSITIVE
  SELECT COUNT(*) INTO @total_rpr_test_positif_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -549,7 +591,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', 'RPR')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
  
  
@@ -558,6 +601,7 @@ SELECT COUNT(*) INTO @total_hiv_test_positif_women
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 INNER JOIN pregnancy_patient_temp pr
@@ -568,7 +612,8 @@ WHERE o.concept_id = concept_from_mapping('PIH', '1040')
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
 
 --  FOR Malaria Test microscopique
  
@@ -576,6 +621,7 @@ WHERE o.concept_id = concept_from_mapping('PIH', '1040')
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.value_coded = concept_from_mapping("PIH","11463")
@@ -583,7 +629,8 @@ WHERE o.value_coded = concept_from_mapping("PIH","11463")
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
  
  
@@ -591,6 +638,7 @@ SELECT COUNT(1) INTO @malaria_test_microscopique_oval
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.value_coded = concept_from_mapping("PIH","20083")
@@ -598,13 +646,15 @@ WHERE o.value_coded = concept_from_mapping("PIH","20083")
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
 
 SELECT COUNT(1) INTO @malaria_test_microscopique_malariae 
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
 WHERE o.value_coded = concept_from_mapping("PIH","20082")
@@ -612,12 +662,14 @@ WHERE o.value_coded = concept_from_mapping("PIH","20082")
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
 SELECT COUNT(1) INTO @malaria_test_microscopique_falciparum 
 FROM obs o 
 INNER JOIN encounter e 
     ON o.encounter_id = e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p
     ON p.person_id = o.person_id
  WHERE o.value_coded = concept_from_mapping("PIH","11461")
@@ -625,7 +677,8 @@ INNER JOIN person p
   AND o.voided = 0 
   AND e.voided = 0
   AND date(e.encounter_datetime) >= @startDate
-  AND date(e.encounter_datetime) < @endDate;
+  AND date(e.encounter_datetime) < @endDate
+  AND v.location_id = @location;
  
 SELECT  (@malaria_test_microscopique_vivax +
          @malaria_test_microscopique_oval +
@@ -655,6 +708,7 @@ INTO
 @PHYSICAL_VIOL_WOMEN_LEFT,@PHYSICAL_VIOL_MEN_LEFT,@PHYSICAL_VIOL_KID_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p ON p.person_id = o.person_id
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
@@ -665,7 +719,8 @@ and o.value_coded =concept_from_mapping("PIH","11533")
 and e.voided =0
 and o.voided =0
 AND date(e.encounter_datetime) >= @startDate
- AND date(e.encounter_datetime) < @endDate;
+ AND date(e.encounter_datetime) < @endDate
+ AND v.location_id = @location;
  
 
 -- SEXUAL VIOLENCE 
@@ -693,6 +748,7 @@ INTO
 @SEX_VIOL_WOMEN_LEFT,@SEX_VIOL_MEN_LEFT,@SEX_VIOL_KIDF_LEFT,@SEX_VIOL_KIDM_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p ON p.person_id = o.person_id
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
@@ -703,7 +759,8 @@ and o.value_coded = concept_from_mapping("PIH","11049")
 and e.voided =0
 and o.voided =0
  AND date(e.encounter_datetime) >= @startDate
-    AND date(e.encounter_datetime) < @endDate;
+    AND date(e.encounter_datetime) < @endDate
+    AND v.location_id = @location;
 
 -- OTHER VIOLENCE
 SELECT 
@@ -723,6 +780,7 @@ INTO @OTHER_SEX_VIOL_WOMEN_DEAD,@OTHER_SEX_VIOL_MEN_DEAD,@OTHER_SEX_VIOL_KID_DEA
 @OTHER_SEX_VIOL_WOMEN_TRANSFER,@OTHER_SEX_VIOL_MEN_TRANSFER,@OTHER_SEX_VIOL_KID_TRANSFER,@OTHER_SEX_VIOL_WOMEN_LEFT,@OTHER_SEX_VIOL_MEN_LEFT,@OTHER_SEX_VIOL_KID_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person p ON p.person_id = o.person_id
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
@@ -737,7 +795,8 @@ where o.concept_id =concept_from_mapping("PIH","3064")
 and e.voided =0
 and o.voided =0
 AND date(e.encounter_datetime) >= @startDate
- AND date(e.encounter_datetime) < @endDate;
+ AND date(e.encounter_datetime) < @endDate
+ AND v.location_id = @location;
  
 -- DOMESTIC ACCIDENT
 SELECT 
@@ -748,6 +807,7 @@ SUM(IF(disp.value_coded=@death,1,0))
 INTO @ACC_DOMES_LEFT,@ACC_DOMES_TREATED,@ACC_DOMES_TRANSFER,@ACC_DOMES_DEAD
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 LEFT JOIN (
 SELECT encounter_id,value_coded  FROM obs WHERE concept_id =concept_from_mapping("PIH","8620")
 GROUP BY encounter_id 
@@ -757,7 +817,8 @@ AND o.value_coded = concept_from_mapping('PIH','Home accident')
 AND e.voided =0
 AND o.voided =0
 AND date(e.encounter_datetime) >= @startDate
-AND date(e.encounter_datetime) < @endDate;
+AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location;
       
 -- WORK ACCIDENT
 SELECT 
@@ -768,6 +829,7 @@ SUM(IF(disp.value_coded=@LeftWithoutSeeingClinician,1,0))
 INTO @ACC_TR_DEAD,@ACC_TR_TREATED,@ACC_TR_TRANSFER,@ACC_TR_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
 GROUP BY encounter_id 
@@ -777,7 +839,8 @@ and o.value_coded = concept_from_mapping("PIH","8851")
 and e.voided =0
 and o.voided =0
 AND date(e.encounter_datetime) >= @startDate
-AND date(e.encounter_datetime) < @endDate;
+AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location;
    
 
  
@@ -790,6 +853,7 @@ SUM(IF(disp.value_coded=@LeftWithoutSeeingClinician,1,0))
 INTO @ACC_TR_MOTOR_DEAD,@ACC_TR_MOTOR_TREATED,@ACC_TR_MOTOR_TRANSFER,@ACC_TR_MOTOR_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
 GROUP BY encounter_id 
@@ -799,7 +863,8 @@ and o.value_coded = concept_from_mapping("PIH","9579")
 and e.voided =0
 and o.voided =0
 AND date(e.encounter_datetime) >= @startDate
-AND date(e.encounter_datetime) < @endDate;
+AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location;
 
 
 -- TRANSPORT-VEHICLE ACCIDENT
@@ -811,6 +876,7 @@ SUM(IF(disp.value_coded=@LeftWithoutSeeingClinician,1,0))
 INTO @ACC_TR_VEHICLE_DEAD,@ACC_TR_VEHICLE_TREATED,@ACC_TR_VEHICLE_TRANSFER,@ACC_TR_VEHICLE_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
 GROUP BY encounter_id 
@@ -820,7 +886,8 @@ and o.value_coded= concept_from_mapping("PIH","9556")
 and e.voided =0
 and o.voided =0
 AND date(e.encounter_datetime) >= @startDate
-AND date(e.encounter_datetime) < @endDate;
+AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location;
 
 -- OTHER ACCIDENTS 
 SELECT 
@@ -831,6 +898,7 @@ SUM(IF(disp.value_coded=@LeftWithoutSeeingClinician,1,0))
 INTO @OTHER_ACC_TR_DEAD,@OTHER_ACC_TR_TREATED,@OTHER_ACC_TR_TRANSFER,@OTHER_ACC_TR_LEFT
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 LEFT JOIN (
 SELECT encounter_id,value_coded  from obs where concept_id =concept_from_mapping("PIH","8620")
 GROUP BY encounter_id 
@@ -840,7 +908,8 @@ and o.value_coded = concept_from_mapping("PIH","8437")
 and e.voided =0
 and o.voided =0
 AND date(e.encounter_datetime) >= @startDate
-AND date(e.encounter_datetime) < @endDate;
+AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location;
 
 -- Urgences Medico-Chirurgicales
 SELECT 
@@ -857,11 +926,13 @@ SUM(IF(o.value_coded=concept_from_mapping('PIH','83'),1,0))
 INTO @UMC_TRAUMA,@UMC_DIGESTIVE,@UMC_RESPIRATORY,@UMC_OBSTETRICS,@UMC_OSTEO_ARTICULAR,@UMC_OTHER
 FROM obs o 
 INNER JOIN encounter e on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 WHERE o.concept_id =concept_from_mapping("PIH","Triage diagnosis")
 AND o.voided =0
 AND e.voided =0
 AND date(e.encounter_datetime) >= @startDate
-AND date(e.encounter_datetime) < @endDate;
+AND date(e.encounter_datetime) < @endDate
+AND v.location_id = @location;
 
 -- ACCOUCHEMENT
 
@@ -910,6 +981,7 @@ SELECT
     @UNKNOWN_AGE_INST
 FROM obs o 
 JOIN encounter e  ON o.encounter_id = e.encounter_id   
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 JOIN person p  ON p.person_id = o.person_id
   LEFT JOIN (
     SELECT encounter_id, value_coded
@@ -921,7 +993,8 @@ JOIN person p  ON p.person_id = o.person_id
    AND o.voided = 0
    AND e.voided = 0
    AND DATE(e.encounter_datetime) >= @startDate
-   AND DATE(e.encounter_datetime) < @endDate;
+   AND DATE(e.encounter_datetime) < @endDate
+   AND v.location_id = @location;
 --    NAISSANCE
 SELECT
 
@@ -959,6 +1032,7 @@ SELECT
 	@INST_NO_WEIGHT
 FROM obs o 
 JOIN encounter e  ON o.encounter_id = e.encounter_id   
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 JOIN person p  ON p.person_id = o.person_id
   LEFT JOIN (
     SELECT encounter_id, value_coded
@@ -976,7 +1050,8 @@ JOIN person p  ON p.person_id = o.person_id
    AND o.voided = 0
    AND e.voided = 0
    AND DATE(e.encounter_datetime) >= @startDate
-   AND DATE(e.encounter_datetime) < @endDate;
+   AND DATE(e.encounter_datetime) < @endDate
+   AND v.location_id = @location;
 --    Client PF
     
   SELECT 
@@ -1161,6 +1236,7 @@ JOIN person p  ON p.person_id = o.person_id
    
     obs o 
    INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+   INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
    INNER JOIN person p ON p.person_id = o.person_id
   LEFT JOIN (
     SELECT encounter_id, value_coded
@@ -1181,7 +1257,8 @@ WHERE
    AND e.voided = 0
    AND o.voided = 0
    AND DATE(e.encounter_datetime) >= @startDate
-   AND DATE(e.encounter_datetime) < @endDate;
+   AND DATE(e.encounter_datetime) < @endDate
+   AND v.location_id = @location;
 
 
 
@@ -1287,10 +1364,11 @@ FROM (
             AND DATE(e2.encounter_datetime) >= @startDate
             AND DATE(e2.encounter_datetime) < @endDate
         ) AS visit_rank
-    FROM obs o 
+    FROM obs o
     JOIN encounter e ON e.encounter_id = o.encounter_id
+    JOIN visit v2 ON e.visit_id = v2.visit_id AND v2.voided = 0
     LEFT JOIN (
-        SELECT 
+        SELECT
             MAX(o.value_datetime) AS edd,
             o.person_id  
         FROM obs o 
@@ -1318,6 +1396,7 @@ FROM (
     AND e.voided = 0
     AND DATE(e.encounter_datetime) >= @startDate
     AND DATE(e.encounter_datetime) < @endDate
+    AND v2.location_id = @location
 ) AS v
 ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 
@@ -1393,6 +1472,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
              @FE_DEATH, @FE_TRANSFER
 		 FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1402,7 +1482,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', 'FEVER')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		   
 		  
 		  SELECT 
@@ -1498,6 +1579,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		   FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		 LEFT JOIN (
 		    SELECT encounter_id, value_coded,obs_group_id
@@ -1511,7 +1593,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', 'MALARIA')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		  SELECT 
@@ -1592,6 +1675,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 
 		     FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id  
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1601,7 +1685,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', 'Severe malaria')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 	    
@@ -1698,6 +1783,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		     FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1707,7 +1793,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', 'Severe malaria')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		  
@@ -1770,6 +1857,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
             @ANX_DEATH,@ANX_TRANSFER
 		     FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1779,7 +1867,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', 'ANXIETY DISORDER')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		
@@ -1841,6 +1930,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		    
 		      FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		   LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1850,7 +1940,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		   WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', 'DEMENTIA')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 
@@ -1916,6 +2007,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		        FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1925,7 +2017,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		  AND o.value_coded = concept_from_mapping('PIH', 'DEPRESSION')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		  
@@ -1986,6 +2079,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		    @SCHIZOPHRENIA_DEATH, @SCHIZOPHRENIA_TRANSFER
 		         FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -1995,7 +2089,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		  AND o.value_coded = concept_from_mapping('PIH', 'SCHIZOPHRENIA')
 		  AND DATE(e.encounter_datetime) >= @startDate
-		  AND DATE(e.encounter_datetime) < @endDate;
+		  AND DATE(e.encounter_datetime) < @endDate
+		  AND v.location_id = @location;
 		  
 		  
 		  
@@ -2056,6 +2151,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		  FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2065,7 +2161,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', '7950')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 	 SELECT
@@ -2123,6 +2220,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			@BIPOLAR_DISO_DEATH,@BIPOLAR_DISO_TRANSFER
 		  FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2132,7 +2230,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		  AND o.value_coded = concept_from_mapping('PIH', 'Bipolar disorder')
 		  AND DATE(e.encounter_datetime) >= @startDate
-		  AND DATE(e.encounter_datetime) < @endDate;
+		  AND DATE(e.encounter_datetime) < @endDate
+		  AND v.location_id = @location;
 		  
 		  
 		 SELECT
@@ -2194,6 +2293,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		    FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2203,7 +2303,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		  AND o.value_coded = concept_from_mapping('PIH', '7201')
 		  AND DATE(e.encounter_datetime) >= @startDate
-		  AND DATE(e.encounter_datetime) < @endDate;
+		  AND DATE(e.encounter_datetime) < @endDate
+		  AND v.location_id = @location;
 		  
 		  
 		  
@@ -2267,6 +2368,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		     FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2276,7 +2378,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', '7951')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		  
@@ -2339,6 +2442,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			@ALCOHOL_USED_DISO_DEATH,   @ALCOHOL_USED_DISO_TRANSFER
 		       FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2348,7 +2452,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', '9522')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		  
@@ -2409,6 +2514,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		    
 		  FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2418,7 +2524,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', '7197')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		  
 		  
 		 SELECT
@@ -2478,6 +2585,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  
 		    FROM  obs o 
 		  INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+		  INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 		  INNER JOIN person p ON p.person_id = o.person_id 
 		  LEFT JOIN (
 		    SELECT encounter_id, value_coded
@@ -2487,7 +2595,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 		  WHERE  e.voided = 0 AND o.voided = 0
 		   AND o.value_coded = concept_from_mapping('PIH', '10633')
 		   AND DATE(e.encounter_datetime) >= @startDate
-		   AND DATE(e.encounter_datetime) < @endDate;
+		   AND DATE(e.encounter_datetime) < @endDate
+		   AND v.location_id = @location;
 		
 		 
 		  -- Maladie Chroniques
@@ -2549,6 +2658,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 
 			FROM obs o 
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -2569,7 +2679,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 
  
 
@@ -2630,6 +2741,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 							
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -2650,7 +2762,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 			
 
 			
@@ -2711,6 +2824,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 								
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -2731,7 +2845,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 
 			
 			
@@ -2793,6 +2908,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 				
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -2813,7 +2929,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 
 		 
 			SELECT 
@@ -2873,6 +2990,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 								
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -2893,7 +3011,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 
  
         SELECT 
@@ -2954,6 +3073,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 				
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -2974,7 +3094,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 
 
 			
@@ -3038,6 +3159,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 				
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -3058,7 +3180,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
  
 
        	SELECT 
@@ -3118,6 +3241,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 				
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -3138,7 +3262,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
  
 
 			SELECT 
@@ -3197,6 +3322,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 								
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -3217,7 +3343,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 
 			
 			SELECT 
@@ -3277,6 +3404,7 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 								
 			FROM obs o  
 			INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+			INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 			INNER JOIN person p ON p.person_id = o.person_id
 			LEFT JOIN (
 				SELECT encounter_id, value_coded  
@@ -3297,7 +3425,8 @@ ORDER BY v.person_id, v.encounter_datetime, v.encounter_id;
 			AND e.voided = 0
 			AND o.voided = 0
 			AND DATE(e.encounter_datetime) >= @startDate
-            AND DATE(e.encounter_datetime) < @endDate;
+            AND DATE(e.encounter_datetime) < @endDate
+            AND v.location_id = @location;
 		  	
 	 
 SELECT  @child_under_1_n  "CHILD_UNDER_1_N",
@@ -3697,4 +3826,4 @@ SELECT  @child_under_1_n  "CHILD_UNDER_1_N",
 			@NEW_RENAL_FAILURE_BET_25_AND_49_F 'NEW_RENAL_FAILURE_BET_25_AND_49_F', @OLD_RENAL_FAILURE_BET_25_AND_49_F 'OLD_RENAL_FAILURE_BET_25_AND_49_F', @NEW_RENAL_FAILURE_BET_25_AND_49_M 'NEW_RENAL_FAILURE_BET_25_AND_49_M', @OLD_RENAL_FAILURE_BET_25_AND_49_M 'OLD_RENAL_FAILURE_BET_25_AND_49_M',
 			@NEW_RENAL_FAILURE_BET_50_AND_MORE_F 'NEW_RENAL_FAILURE_BET_50_AND_MORE_F', @OLD_RENAL_FAILURE_BET_50_AND_MORE_F 'OLD_RENAL_FAILURE_BET_50_AND_MORE_F', @NEW_RENAL_FAILURE_BET_50_AND_MORE_M 'NEW_RENAL_FAILURE_BET_50_AND_MORE_M', @OLD_RENAL_FAILURE_BET_50_AND_MORE_M 'OLD_RENAL_FAILURE_BET_50_AND_MORE_M',
 			@RENAL_FAILURE_DEAD 'RENAL_FAILURE_DEAD', @NEW_RENAL_FAILURE_DISCHARGED 'NEW_RENAL_FAILURE_DISCHARGED', 
-			@OLD_RENAL_FAILURE_DISCHARGED 'OLD_RENAL_FAILURE_DISCHARGED';
+			@OLD_RENAL_FAILURE_DISCHARGED 'OLD_RENAL_FAILURE_DISCHARGED';

--- a/configuration/reports/reportdescriptors/dataexports/sql/newDiseaseEpisodes.sql
+++ b/configuration/reports/reportdescriptors/dataexports/sql/newDiseaseEpisodes.sql
@@ -204,6 +204,8 @@ end) 'Diagnosis',
 (CASE when round(DATEDIFF(o.obs_datetime, pr.birthdate)/365.25, 1) > 50 and pr.gender = 'M' then 1 else 0 end) "MG50",
 (CASE when round(DATEDIFF(o.obs_datetime, pr.birthdate)/365.25, 1) > 50 and pr.gender = 'F' then 1 else 0 end) "FG50"
 from obs o
+INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN person pr on pr.person_id = o.person_id
 INNER JOIN report_mapping rm on o.value_coded = rm.concept_id
 LEFT OUTER JOIN obs oc on oc.encounter_id = o.encounter_id and oc.voided = 0 and oc.obs_group_id = o.obs_group_id and oc.concept_id =
@@ -211,15 +213,16 @@ LEFT OUTER JOIN obs oc on oc.encounter_id = o.encounter_id and oc.voided = 0 and
 LEFT OUTER JOIN concept_name c_name on c_name.concept_id = oc.value_coded and  c_name.locale = 'en' and c_name.locale_preferred = '1' and c_name.voided = 0
 where o.concept_id = (select concept_id from report_mapping where source = 'PIH' and code = 'DIAGNOSIS')
 and not exists -- qualify result for NEW diagnoses
-   (select 1 from obs o_prev 
-    where o_prev.obs_id <> o.obs_id   
+   (select 1 from obs o_prev
+    where o_prev.obs_id <> o.obs_id
     and o_prev.person_id = o.person_id
     and o_prev.concept_id = o.concept_id
     and o_prev.value_coded = o.value_coded
     )
-and o.voided = 0 
+and o.voided = 0
 AND date(o.obs_datetime) >= @startDate
 AND date(o.obs_datetime) < @endDate
+AND v.location_id = @location
 group by o.obs_id, rm.source, rm.code
 ) oo
 where diagnosis is not null

--- a/configuration/reports/reportdescriptors/dataexports/sql/weeklyMonitoring.sql
+++ b/configuration/reports/reportdescriptors/dataexports/sql/weeklyMonitoring.sql
@@ -96,17 +96,20 @@ obs_id,
 obs_group_id,
 diagnosis_concept_id
 )
-select 
+select
 o.person_id,
 o.encounter_id,
 o.obs_id,
 o.obs_group_id ,
-o.value_coded 
-from obs o 
+o.value_coded
+from obs o
+INNER JOIN encounter e ON o.encounter_id = e.encounter_id AND e.voided = 0
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 where concept_id = @diagnosis
 AND o.voided = 0
 AND ((date(o.obs_datetime) >=@startDate) or @startDate is null)
 AND ((date(o.obs_datetime) <=@endDate)  or @endDate is null)
+AND v.location_id = @location
 and o.value_coded in (
 @cholera,
 @diphtheria_probable,

--- a/configuration/reports/reportdescriptors/dataexports/sql/womenHealthReport.sql
+++ b/configuration/reports/reportdescriptors/dataexports/sql/womenHealthReport.sql
@@ -96,9 +96,10 @@ SELECT
     INTO
           @MET_COC_LESS_THAN_25_ACCEPTED,@MET_COP_LESS_THAN_25_ACCEPTED,@MET_DEPO_PROVERA_LESS_THAN_25_ACCEPTED,@MET_IMPL_LESS_THAN_25_ACCEPTED,@MET_DIU_LESS_THAN_25_ACCEPTED,@MET_CONDOM_LESS_THAN_25_ACCEPTED,@MET_MAMA_LESS_THAN_25_ACCEPTED,@MET_COLLIER_LESS_THAN_25_ACCEPTED,@MET_CCV_LESS_THAN_25_ACCEPTED,
           @MET_COC_MORE_25_ACCEPTED,@MET_COP_MORE_25_ACCEPTED,@MET_DEPO_PROVERA_MORE_25_ACCEPTED,@MET_IMPL_MORE_25_ACCEPTED,@MET_DIU_USED_MORE_25_ACCEPTED,@MET_CONDOM_MORE_25_ACCEPTED,@MET_MAMA_MORE_25_ACCEPTED,@MET_COLLIER_MORE_25_ACCEPTED,@MET_CCV_MORE_25_ACCEPTED
-    FROM 
-    obs o 
-   INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+    FROM
+    obs o
+   INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+   INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
    INNER JOIN person p ON p.person_id = o.person_id
    LEFT JOIN (
 	    SELECT encounter_id, value_coded
@@ -114,7 +115,8 @@ SELECT
     AND e.voided = 0
     AND o.voided = 0
     AND DATE(e.encounter_datetime) >= @startDate
-    AND DATE(e.encounter_datetime) < @endDate;
+    AND DATE(e.encounter_datetime) < @endDate
+    AND v.location_id = @location;
 
   SELECT 
   SUM(IF( planing_method.value_coded=concept_from_mapping("PIH","1719") 
@@ -128,9 +130,10 @@ SELECT
     INTO
       @MET_CCV,@MET_IMPL,@MET_DIU
 
-    FROM 
-    obs o 
-   INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+    FROM
+    obs o
+   INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+   INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
    INNER JOIN person p ON p.person_id = o.person_id
    LEFT JOIN (
 	    SELECT encounter_id, value_coded
@@ -142,7 +145,8 @@ SELECT
     AND e.voided = 0
     AND o.voided = 0
     AND DATE(e.encounter_datetime) >= @startDate
-    AND DATE(e.encounter_datetime) < @endDate;
+    AND DATE(e.encounter_datetime) < @endDate
+    AND v.location_id = @location;
 
 
 -- NUMBER 0F CONDOMS DONATED
@@ -150,9 +154,10 @@ SELECT
      SUM(nb_of_condoms.value_numeric)
     INTO
       @NB_OF_CONDOMS
-    FROM 
-    obs o 
-   INNER JOIN encounter e ON o.encounter_id = e.encounter_id 
+    FROM
+    obs o
+   INNER JOIN encounter e ON o.encounter_id = e.encounter_id
+   INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
    INNER JOIN person p ON p.person_id = o.person_id
    LEFT JOIN (
 	    SELECT encounter_id, value_numeric  
@@ -164,7 +169,8 @@ SELECT
     AND e.voided = 0
     AND o.voided = 0
     AND DATE(e.encounter_datetime) >= @startDate
-    AND DATE(e.encounter_datetime) < @endDate;
+    AND DATE(e.encounter_datetime) < @endDate
+    AND v.location_id = @location;
 
 -- B1 Prenatal consultation
 SELECT
@@ -193,8 +199,9 @@ SELECT
             WHEN o.concept_id = concept_from_mapping("PIH","3267")
             AND  o.value_datetime IS NOT NULL
             THEN 1 ELSE 0 END)
-INTO  @ANC_1ST_VISIT_T1,@ANC_1ST_VISIT_T2,@ANC_1ST_VISIT_T3,@ANC_1ST_VISIT_GA_UNK,@ANC_1ST_VISIT_HIV_TESTED,@ANC_1ST_VISIT_HIV_POS,@ANC_1ST_VISIT_SYPH_TESTED 
+INTO  @ANC_1ST_VISIT_T1,@ANC_1ST_VISIT_T2,@ANC_1ST_VISIT_T3,@ANC_1ST_VISIT_GA_UNK,@ANC_1ST_VISIT_HIV_TESTED,@ANC_1ST_VISIT_HIV_POS,@ANC_1ST_VISIT_SYPH_TESTED
 FROM encounter e
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN (
     SELECT
         e.encounter_id
@@ -241,7 +248,8 @@ INNER JOIN person p
     AND o.voided = 0
     AND e.voided = 0
     WHERE  e.encounter_datetime >=  @startDate
-	AND e.encounter_datetime <   @endDate;
+	AND e.encounter_datetime <   @endDate
+	AND v.location_id = @location;
 
 
 SELECT
@@ -280,6 +288,7 @@ FROM (
             WHEN o_trimester.value_coded = concept_from_mapping('PIH','10902') THEN 'Trim3'
         END AS trimestre
     FROM encounter fs
+    INNER JOIN visit v_fs ON fs.visit_id = v_fs.visit_id AND v_fs.voided = 0
     INNER JOIN obs o_suivi
         ON o_suivi.encounter_id = fs.encounter_id
         AND o_suivi.value_coded = concept_from_mapping('PIH','7383')
@@ -336,6 +345,7 @@ FROM (
       AND fs.encounter_datetime >=  @startDate
       AND fs.encounter_datetime <   @endDate
       AND fs.voided = 0
+      AND v_fs.location_id = @location
     GROUP BY fs.patient_id, fs.encounter_id, o_trimester.value_coded
 ) x;
 
@@ -343,8 +353,9 @@ FROM (
 SELECT 
 COUNT(x.person_id ) INTO @ANC_DPA_MONTH
 FROM (
-SELECT o.person_id FROM encounter e 
-INNER JOIN obs o on o.encounter_id =e.encounter_id 
+SELECT o.person_id FROM encounter e
+INNER JOIN obs o on o.encounter_id =e.encounter_id
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN (
         SELECT
             e.patient_id,e.encounter_id ,
@@ -363,20 +374,22 @@ INNER JOIN (
     ) last_nv
         ON last_nv.patient_id = e.patient_id
 WHERE
- e.encounter_datetime = last_nv.last_new_visit_date 
+ e.encounter_datetime = last_nv.last_new_visit_date
  AND e.encounter_datetime >= @startDate
  AND e.encounter_datetime <  @endDate
  AND o.voided =0
  AND e.voided =0
  AND o.concept_id =concept_from_mapping('PIH','5596')
- GROUP BY o.person_id 
+ AND v.location_id = @location
+ GROUP BY o.person_id
  )x;
 
 -- # of high-risk pregnancies
 SELECT COUNT(x.person_id ) INTO @ANC_PREG_HR_CONDITIONS
  FROM (
     SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -395,20 +408,22 @@ SELECT COUNT(x.person_id ) INTO @ANC_PREG_HR_CONDITIONS
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime   >= last_nv.last_new_visit_date 
+    e.encounter_datetime   >= last_nv.last_new_visit_date
     AND e.encounter_datetime >=  @startDate
     AND e.encounter_datetime <  @endDate
     AND o.voided =0
     AND e.voided =0
     AND o.concept_id =concept_from_mapping('PIH','11673')
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
  )x;
 
 -- # of pregnant women who had their first visit since October during the month of the report.
  SELECT COUNT(x.person_id ) INTO  @ANC_1ST_VISIT_SINCE_OCT_MONTH
   FROM (
     SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -427,21 +442,23 @@ SELECT COUNT(x.person_id ) INTO @ANC_PREG_HR_CONDITIONS
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime = last_nv.last_new_visit_date 
+    e.encounter_datetime = last_nv.last_new_visit_date
     AND e.encounter_datetime >=  @startDate
     AND e.encounter_datetime <  @endDate
     AND o.voided =0
     AND e.voided =0
     AND o.value_coded = concept_from_mapping('PIH','6259')
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
  )x;
 
 -- number of pregnant women who received iron during prenatal visits (ferrous sulfate, iron, iron dextran)
 SELECT COUNT(x.person_id ) INTO  @ANC_PREG_IRON_SUPP_COUNT
     FROM (
-    SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    SELECT o.person_id FROM encounter e
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
     INNER JOIN orders o2 on o2.encounter_id = e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -460,7 +477,7 @@ SELECT COUNT(x.person_id ) INTO  @ANC_PREG_IRON_SUPP_COUNT
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime >= last_nv.last_new_visit_date 
+    e.encounter_datetime >= last_nv.last_new_visit_date
     AND e.encounter_datetime >=  @startDate
     AND e.encounter_datetime <  @endDate
     AND o.voided =0
@@ -468,7 +485,8 @@ SELECT COUNT(x.person_id ) INTO  @ANC_PREG_IRON_SUPP_COUNT
     AND o.value_coded = concept_from_mapping('PIH','6259')
     and o2.concept_id in (concept_from_mapping('PIH','256'),concept_from_mapping('PIH','9267'))
     AND o2.voided =0
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
   )x;
 
 
@@ -479,6 +497,7 @@ SELECT COUNT(x.person_id ) INTO  @ANC_PREG_IRON_SUPP_COUNT
        COUNT(*)
    INTO @PNC_1ST_VISIT_TOTAL
 FROM encounter e
+INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
 INNER JOIN (
     SELECT
         e.encounter_id
@@ -519,13 +538,15 @@ INNER JOIN (
 ) last_encounters
     ON last_encounters.encounter_id = e.encounter_id
     WHERE  e.encounter_datetime >= @startDate
-	AND e.encounter_datetime <  @endDate;
+	AND e.encounter_datetime <  @endDate
+	AND v.location_id = @location;
 
 -- # of women who gave birth at another facility
 SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
  FROM (
     SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -544,13 +565,14 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime   >= last_nv.last_new_visit_date 
+    e.encounter_datetime   >= last_nv.last_new_visit_date
     AND o.voided =0
     AND e.voided =0
     AND o.concept_id =concept_from_mapping('PIH','11348')
     AND o.value_coded  =concept_from_mapping('PIH','8856')
     AND e.encounter_datetime >= @startDate
     AND e.encounter_datetime <  @endDate
+    AND v.location_id = @location
     GROUP BY o.person_id
  )x;
 
@@ -559,7 +581,8 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
  SELECT COUNT(x.person_id ) INTO @FP_METHOD_ACCEPTED_SUBSET
  FROM (
     SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -578,13 +601,14 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime   >= last_nv.last_new_visit_date 
+    e.encounter_datetime   >= last_nv.last_new_visit_date
     AND o.voided =0
     AND e.voided =0
     AND o.concept_id =concept_from_mapping('PIH','374')
     AND e.encounter_datetime >= @startDate
     AND e.encounter_datetime <  @endDate
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
  )x;
 
 
@@ -592,7 +616,8 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
  SELECT COUNT(x.person_id ) INTO @PNC_VIT_A_GIVEN
  FROM (
     SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -611,14 +636,15 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime   >= last_nv.last_new_visit_date 
+    e.encounter_datetime   >= last_nv.last_new_visit_date
     AND o.voided =0
     AND e.voided =0
     AND o.concept_id =concept_from_mapping('PIH','13255')
     AND o.value_coded  =concept_from_mapping('PIH','4063')
     AND e.encounter_datetime >= @startDate
     AND e.encounter_datetime <  @endDate
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
  )x;
 
 
@@ -626,7 +652,8 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
  SELECT COUNT(x.person_id ) INTO @PREG_HOME_DELIV_ANC_FACILITY
  FROM (
     SELECT o.person_id FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -645,14 +672,15 @@ SELECT COUNT(x.person_id ) INTO @DELIVERY_EXT_FACILITY_COUNT
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime   >= last_nv.last_new_visit_date 
+    e.encounter_datetime   >= last_nv.last_new_visit_date
     AND o.voided =0
     AND e.voided =0
     AND o.concept_id =concept_from_mapping('PIH','11348')
     AND o.value_coded  =concept_from_mapping('PIH','7889')
     AND e.encounter_datetime >= @startDate
     AND e.encounter_datetime <  @endDate
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
  )x;
 
 -- # of women seen at their first postnatal visit during the reporting month within 72 hours of delivery
@@ -664,7 +692,8 @@ SELECT
     END) INTO  @PNC_FIRST_VISIT_LT72H_MONTH
  FROM (
     SELECT o.person_id,o.value_datetime,last_nv.last_new_visit_date  FROM encounter e 
-    INNER JOIN obs o on o.encounter_id =e.encounter_id 
+    INNER JOIN obs o on o.encounter_id =e.encounter_id
+    INNER JOIN visit v ON e.visit_id = v.visit_id AND v.voided = 0
     INNER JOIN (
             SELECT
                 e.patient_id,e.encounter_id ,
@@ -683,13 +712,14 @@ SELECT
         ) last_nv
             ON last_nv.patient_id = e.patient_id
     WHERE
-    e.encounter_datetime   >= last_nv.last_new_visit_date 
+    e.encounter_datetime   >= last_nv.last_new_visit_date
     AND o.voided =0
     AND e.voided =0
     AND o.concept_id =concept_from_mapping('PIH','5599')
     AND e.encounter_datetime >=  @startDate
     AND e.encounter_datetime <  @endDate
-    GROUP BY o.person_id 
+    AND v.location_id = @location
+    GROUP BY o.person_id
  )x;
 
 -- SECTION C
@@ -744,6 +774,10 @@ FROM
         ON e.encounter_id = d.encounter_id
        AND e.voided = 0
 
+    INNER JOIN visit v
+        ON v.visit_id = e.visit_id
+       AND v.voided = 0
+
     INNER JOIN obs t
         ON t.encounter_id = d.encounter_id
        AND t.person_id = d.person_id
@@ -759,6 +793,7 @@ FROM
       AND d.voided = 0
       AND e.encounter_datetime >= @startDate
       AND e.encounter_datetime < @endDate
+      AND v.location_id = @location
 
 ) x;
 

--- a/configuration/reports/reportdescriptors/dataexports/womenHealthReport.yml
+++ b/configuration/reports/reportdescriptors/dataexports/womenHealthReport.yml
@@ -9,6 +9,11 @@ parameters:
   - key: "endDate"
     type: "java.util.Date"
     label: "reporting.parameter.endDate"
+  - key: "location"
+    type: "org.openmrs.Location"
+    label: "reporting.parameter.location"
+    widgetConfiguration:
+     withTag: "Visit Location"
 datasets:
   - key: "womenHealthReport"
     type: "sql"


### PR DESCRIPTION
So I'm worried I might know "just enough to be dangerous" here... @dmdesimone @louidorjp ...

What this change is doing is changing all the monitoring reports (and, specifically, the queries to the obs table) so that for each query it joins the obs to it's related encounter and then the encounter to the related visit, so that on the combined "ZL Central" server we can limit the reports to only count "obs reported during visits at Cange" or "obs reported during visits at Mirebalais"

What this will miss would be if there are any data points that *aren't* connected as part of a visit, these will now not show up in the report.

I'm wondering if have any test data on HUM-CI or elsewhere that we can use to test that these reports are still working properly?


