### PR TITLE
UHM-9480 Add sonatype release workflow, allow snapshot dependencies

### DIFF
--- a/.github/workflows/release-to-sonatype.yml
+++ b/.github/workflows/release-to-sonatype.yml
@@ -1,0 +1,9 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/release-to-sonatype.yml@main
+    secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
                     <configuration>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+                        <ignoreSnapshots>true</ignoreSnapshots>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Summary
- Add `release-to-sonatype.yml` GitHub Action (workflow_dispatch), delegating to the `PIH/openmrs-contrib-distro-tools` reusable release workflow — matches the pihemr repo's existing setup.
- Set `ignoreSnapshots=true` on `maven-release-plugin` so the release build doesn't fail when SNAPSHOT dependencies are present.
- The released artifact is ultimately consumed as a distro zip or docker image containing the actual built artifacts, so the transitive SNAPSHOT dependency references don't affect reproducibility.

## Test plan
- [ ] Confirm the `SONATYPE_USERNAME`/`SONATYPE_PASSWORD`/`SONATYPE_GPG_PASSPHRASE`/`SONATYPE_GPG_PRIVATE_KEY` secrets are available to this repo (org-level or repo-level)
- [ ] Run the "Release new version" GitHub Action and confirm `release:prepare`/`release:perform` succeed with SNAPSHOT dependencies present