### PR TITLE
UHM-9480 Allow snapshot dependencies in maven release, deploy to JFrog

### DIFF
--- a/.github/workflows/build-and-deploy-to-openmrs-jfrog.yml
+++ b/.github/workflows/build-and-deploy-to-openmrs-jfrog.yml
@@ -12,7 +12,7 @@ jobs:
     concurrency:
       group: build-and-deploy-${{ github.ref }}
       cancel-in-progress: true
-    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/build-and-deploy.yml@main
+    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/build-and-deploy-to-openmrs-jfrog.yml@main
     with:
       image_name: partnersinhealth/zl-emr
       maven_profiles: distro-zip

--- a/.github/workflows/release-to-openmrs-jfrog.yml
+++ b/.github/workflows/release-to-openmrs-jfrog.yml
@@ -1,0 +1,12 @@
+name: Release new version
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/release-to-openmrs-jfrog.yml@main
+    secrets: inherit

--- a/.github/workflows/release-to-openmrs-jfrog.yml
+++ b/.github/workflows/release-to-openmrs-jfrog.yml
@@ -9,4 +9,7 @@ permissions:
 jobs:
   release:
     uses: PIH/openmrs-contrib-distro-tools/.github/workflows/release-to-openmrs-jfrog.yml@main
+    with:
+      image_name: partnersinhealth/zl-emr
+      maven_profiles: distro-zip
     secrets: inherit

--- a/.github/workflows/release-to-sonatype.yml
+++ b/.github/workflows/release-to-sonatype.yml
@@ -1,9 +1,0 @@
-name: Release new version
-
-on:
-  workflow_dispatch:
-
-jobs:
-  release:
-    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/release-to-sonatype.yml@main
-    secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -62,22 +62,13 @@
                     <version>3.8.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.central</groupId>
-                    <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.11.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.7</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.2.0</version>
                     <configuration>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+                        <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -91,57 +82,20 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                    <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>release</id>
-            <activation>
-                <property>
-                    <name>deployRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <!--
-                    To deploy non-snapshot versions to Sonatype, signatures must be generated using gpg
-                    Instructions for creating a key:
-                    https://central.sonatype.org/pages/working-with-pgp-signatures.html
-                    Command to run: clean deploy -U -DdeployRelease -Dgpg.passphrase=*** -Dgpg.keyname=[email_address_associated_with_generated_key]
-                    -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <signer>bc</signer>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+    <distributionManagement>
+        <repository>
+            <id>openmrs-repo-modules-pih</id>
+            <name>Modules</name>
+            <url>https://openmrs.jfrog.io/artifactory/modules-pih/</url>
+        </repository>
+        <snapshotRepository>
+            <id>openmrs-repo-modules-pih</id>
+            <name>OpenMRS Snapshots</name>
+            <url>https://openmrs.jfrog.io/artifactory/modules-pih-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <repositories>
         <repository>


### PR DESCRIPTION
## Summary
- Adds `allowTimestampedSnapshots=true` to the `maven-release-plugin` config so `release:prepare` doesn't fail on SNAPSHOT dependencies (e.g. the `pihemr-distro`/`pihcore` chain, which hasn't cut a real release yet).
- Switches the deploy target from Sonatype Central to the OpenMRS JFrog `modules-pih`/`modules-pih-snapshots` repos, matching `openmrs-module-pihcore`. Central enforces a hard server-side rule rejecting released artifacts that declare SNAPSHOT dependencies; JFrog does not.
- Removes `central-publishing-maven-plugin` and the GPG-signing `release` profile, both specific to Sonatype Central's publishing requirements and unneeded for JFrog.
- Renames `.github/workflows/release-to-sonatype.yml` to `release-to-openmrs-jfrog.yml`, pointing at the new reusable workflow of the same name in `openmrs-contrib-distro-tools` (PIH/openmrs-contrib-distro-tools#4), and adds the `permissions: contents: write` block that reusable workflow's README requires.

## Test plan
- [ ] Merge PIH/openmrs-contrib-distro-tools#4 and PIH/pihemr#747 first.
- [ ] `mvn release:prepare -DdryRun=true` completes without failing on any SNAPSHOT dependency.
- [ ] Trigger the `Release new version` workflow via `workflow_dispatch` and confirm it deploys to JFrog successfully.