### PR TITLE
UHM-9497 - Add smoke-tests caller workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  hum-ci:
+  zl-ci:
     if: github.repository_owner == 'PIH'
     uses: PIH/openmrs-contrib-distro-tools/.github/workflows/execute-pihemr-smoke-tests.yml@main
     with:
       image_name: partnersinhealth/zl-emr
       instance_name: hum-ci
-      pih_config: mirebalais,mirebalais-humci
-      seed_image_name: partnersinhealth/zl-emr-seed-mirebalais
+      pih_config: haiti,haiti-central,haiti-local-idgen
+      seed_image_name: partnersinhealth/zl-emr-seed-haiti
       suite: zlCentral
     secrets: inherit

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  haiti:
+  hum-ci:
     if: github.repository_owner == 'PIH'
     uses: PIH/openmrs-contrib-distro-tools/.github/workflows/execute-pihemr-smoke-tests.yml@main
     with:
       image_name: partnersinhealth/zl-emr
-      pih_config: haiti
+      instance_name: hum-ci
+      pih_config: mirebalais,mirebalais-humci
+      seed_image_name: partnersinhealth/zl-emr-seed-mirebalais
       suite: zlCentral
     secrets: inherit

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   haiti:
     if: github.repository_owner == 'PIH'
-    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/smoke-test.yml@main
+    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/execute-pihemr-smoke-tests.yml@main
     with:
       image_name: partnersinhealth/zl-emr
       pih_config: haiti

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,14 @@
+name: Smoke tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  haiti:
+    if: github.repository_owner == 'PIH'
+    uses: PIH/openmrs-contrib-distro-tools/.github/workflows/smoke-test.yml@main
+    with:
+      image_name: partnersinhealth/zl-emr
+      pih_config: haiti
+      suite: zlCentral
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-only caller workflow that runs smoke tests for the `haiti` pih_config (using the `zlCentral` smoke suite) against a throwaway OpenMRS+DB stack seeded from the nightly seed image, via the new reusable `execute-pihemr-smoke-tests.yml` workflow in `openmrs-contrib-distro-tools`.
- Replaces the corresponding Bamboo smoke-test plan (`humci`) for this site (Bamboo plan retirement is a separate follow-up). The `mirebalais` pih_config intentionally gets no smoke-test job — it has no Bamboo coverage today either.

## Dependency
This workflow calls `PIH/openmrs-contrib-distro-tools/.github/workflows/execute-pihemr-smoke-tests.yml@main`, which doesn't exist on `main` yet — see PIH/openmrs-contrib-distro-tools#6. It can be merged independently, but the workflow itself won't successfully resolve/run until that PR merges.

## Test plan
- [x] YAML syntax validated
- [x] `with:` inputs cross-checked against the reusable workflow's declared inputs
- [ ] Manual `workflow_dispatch` run once PIH/openmrs-contrib-distro-tools#6 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)