### PR TITLE
UHM-9493: fix 'Screen for syphilis' date field hidden when checked

### DIFF
--- a/content/configuration/backend_configuration/pih/scripts/global/zl.js
+++ b/content/configuration/backend_configuration/pih/scripts/global/zl.js
@@ -171,19 +171,12 @@ function phoneNumberPattern() {
  * @param widgetId
  */
 function setUpObsWithObsDateTime(widgetId) {
+  // The show/hide/clear of the obs date field for a checkbox obs is now handled natively by the
+  // htmlformentry module (setupCheckboxDateToggle, HTML-893). This helper only needs to restrict the
+  // date picker to non-future dates; doing the hide/show here as well conflicts with the module and
+  // leaves the date input hidden on edit-load when the checkbox is already checked.
   if (getField(widgetId + '.date') && getField(widgetId + '.value')) {
-    getField(widgetId + '.date').hide();
     getField(widgetId + '.date').datepicker('option', 'maxDate', new Date());
-
-    getField(widgetId + '.value').change(function () {
-      const isChecked = getValue(widgetId + '.value');
-      if (isChecked) {
-        getField(widgetId + '.date').show();
-      } else {
-        setValue(widgetId + '.date', '')
-        getField(widgetId + '.date').hide();
-      }
-    })
   }
 }
 


### PR DESCRIPTION
openmrs/openmrs-module-htmlformentry/pull/349 made a fix to `<obs style="checkbox" dateLabel="blah">` element to only show the date label and date field for the obs when the checkbox is checked. This conflicts with the custom `setUpObsWithObsDateTime` function here, which has its own logic to hide the date label and date field. This PR takes that stuff out, and only keeps the logic to limit the date field's `maxDate` to current date.

I confirmed that the `setUpObsWithObsDateTime` function is only in this repo, and is only used for the `#syph-checkbox` obs element.

Testing done:
In patient's visit dash, opened PMTCT-followup.xml form (in ENTER mode), which immediately saves. Reopen form in EDIT mode to verify that, when the checkbox is not checked,  the date label and field are not shown:

<img width="2454" height="461" alt="image" src="https://github.com/user-attachments/assets/12d83ebd-9ad0-48d0-a2e4-addc0f1eee7d" />

After checking the box, entering a date and save, reopen and form and confirm that the date label and field are shown and populated with the entered value:
<img width="2454" height="461" alt="image" src="https://github.com/user-attachments/assets/06543280-e8e1-4192-bcaf-4d61966258ef" />
 